### PR TITLE
Add SSL verification toggle for Portainer client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # streamlit-portainer-dashboard
-A streamlit application that pulls information from the portainer api and visualizes everything
+
+A streamlit application that pulls information from the Portainer API and visualizes everything.
+
+## Configuration
+
+The application is configured via environment variables:
+
+- `PORTAINER_API_URL` – Base URL of your Portainer instance (e.g. `https://portainer.example.com/api`).
+- `PORTAINER_API_KEY` – API key used for authentication.
+- `PORTAINER_VERIFY_SSL` – Optional. Set to `false` to disable TLS certificate verification when using self-signed certificates.


### PR DESCRIPTION
## Summary
- add a configuration flag that lets the Portainer client skip TLS verification
- document the new environment variable in the README to guide users with self-signed certificates

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e112bd50108333982e3769abb98f7f