### PR TITLE
Fix refresh button for Streamlit rerun API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -129,7 +129,7 @@ page_options = [
 with st.sidebar:
     if st.button("🔄 Refresh data", use_container_width=True):
         get_cached_data.clear()
-        st.experimental_rerun()
+        st.rerun()
 
     st.header("Navigation")
     selected_page = st.radio(


### PR DESCRIPTION
## Summary
- replace the deprecated Streamlit `experimental_rerun` call with the supported `st.rerun()` API so the refresh button works again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e11dfd4cac8333b1bdf77042c7df5a