### PR TITLE
Add CI workflow to verify Streamlit app starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Verify Streamlit app starts
+        run: |
+          chmod +x scripts/check_app_starts.sh
+          scripts/check_app_starts.sh

--- a/scripts/check_app_starts.sh
+++ b/scripts/check_app_starts.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STREAMLIT_CMD=(
+  streamlit run app/main.py \
+    --server.headless true \
+    --server.port 8501 \
+    --server.address 127.0.0.1 \
+    --browser.gatherUsageStats false \
+    --server.fileWatcherType none
+)
+
+"${STREAMLIT_CMD[@]}" &
+APP_PID=$!
+
+cleanup() {
+  if kill -0 "$APP_PID" 2>/dev/null; then
+    kill "$APP_PID" 2>/dev/null || true
+    wait "$APP_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+  if curl -sf http://127.0.0.1:8501/_stcore/health >/dev/null; then
+    echo "Streamlit app responded successfully."
+    exit 0
+  fi
+
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    echo "Streamlit process exited before health check succeeded." >&2
+    exit 1
+  fi
+
+  sleep 1
+done
+
+echo "Timed out waiting for Streamlit health endpoint." >&2
+exit 1


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs a startup check for the Streamlit app
- create a reusable script that boots the app in headless mode and confirms the health endpoint responds

## Testing
- ./scripts/check_app_starts.sh

------
https://chatgpt.com/codex/tasks/task_e_68e124aee1bc8333ade4128f7867ad74