### PR TITLE
Fix session state update when saving environments

### DIFF
--- a/app/pages/5_Settings.py
+++ b/app/pages/5_Settings.py
@@ -37,7 +37,11 @@ env_names = [env.get("name", "") for env in environments_state if env.get("name"
 
 form_selection_key = "portainer_env_form_selection"
 prev_selection_key = "portainer_env_form_prev_selection"
+pending_selection_key = "portainer_env_form_pending_selection"
 options = ["New environment", *env_names]
+
+if pending_selection := st.session_state.pop(pending_selection_key, None):
+    st.session_state[form_selection_key] = pending_selection
 
 if st.session_state.get(form_selection_key) not in options:
     default_env = get_selected_environment_name() or "New environment"
@@ -125,7 +129,7 @@ if submitted:
             updated_envs[edit_index] = updated_env
         set_saved_environments(updated_envs)
         set_active_environment(name_value)
-        st.session_state[form_selection_key] = name_value
+        st.session_state[pending_selection_key] = name_value
         st.session_state[prev_selection_key] = name_value
         clear_cached_data()
         st.experimental_rerun()


### PR DESCRIPTION
## Summary
- ensure the settings page defers updating the environment selectbox state until the next render
- prevent Streamlit from raising when saving a new environment updates the selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12a37fa0c8333918e524d8d81b5de