### PR TITLE
Update README with development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,23 @@ The application is configured via environment variables:
      streamlit-portainer-dashboard
    ```
 5. Visit http://localhost:8501 to access the dashboard. Any Portainer environments you add inside the app will be stored in the mounted volume and remain available for future container runs.
+
+## Development
+
+### Run tests
+
+Compile the Streamlit app to ensure there are no syntax errors:
+
+```bash
+python -m compileall app
+```
+
+### Build and run locally
+
+Build the Docker image, create the volume used for persisted Streamlit data, and start the container:
+
+```bash
+docker build -t streamlit-portainer-dashboard .
+docker volume create streamlit_portainer_envs
+docker run -p 8501:8501 --env-file .env -v streamlit_portainer_envs:/app/.streamlit streamlit-portainer-dashboard
+```


### PR DESCRIPTION
## Summary
- document the compile-time test command used to validate the Streamlit app
- add build and run instructions for local Docker development to the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12e0dbd1083339a56e94f466cf364