### PR TITLE
Fix Streamlit rerun API usage and update layout width options

### DIFF
--- a/app/dashboard_state.py
+++ b/app/dashboard_state.py
@@ -38,6 +38,7 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover - fallback when e
 __all__ = [
     "ConfigurationError",
     "NoEnvironmentsConfiguredError",
+    "trigger_rerun",
     "FilterResult",
     "apply_selected_environment",
     "clear_cached_data",
@@ -67,6 +68,15 @@ SESSION_FILTER_ENVIRONMENTS = "portainer_filter_selected_environments"
 SESSION_FILTER_ENDPOINTS = "portainer_filter_selected_endpoints"
 SESSION_FILTER_STACK_SEARCH = "portainer_filter_stack_search"
 SESSION_FILTER_CONTAINER_SEARCH = "portainer_filter_container_search"
+
+
+def trigger_rerun() -> None:
+    """Request Streamlit to rerun the script, handling legacy APIs."""
+
+    rerun = getattr(st, "rerun", None) or getattr(st, "experimental_rerun", None)
+    if rerun is None:  # pragma: no cover - unexpected runtime configuration
+        raise AttributeError("Streamlit rerun API is unavailable")
+    rerun()
 
 
 def initialise_session_state() -> None:
@@ -285,9 +295,9 @@ def render_sidebar_filters(
     """Render common sidebar controls and return the applied filters."""
 
     with st.sidebar:
-        if st.button("🔄 Refresh data", use_container_width=True):
+        if st.button("🔄 Refresh data", width="stretch"):
             clear_cached_data()
-            st.experimental_rerun()
+            trigger_rerun()
 
         saved_envs = get_saved_environments()
         env_names = [env.get("name", "") for env in saved_envs if env.get("name")]
@@ -303,7 +313,7 @@ def render_sidebar_filters(
             )
             if selection != current_name:
                 set_active_environment(selection)
-                st.experimental_rerun()
+                trigger_rerun()
         else:
             st.info("No saved environments. Use the Settings page to add one.")
 

--- a/app/pages/1_Overview.py
+++ b/app/pages/1_Overview.py
@@ -129,7 +129,7 @@ with tab_details:
             "Stack status": st.column_config.TextColumn(),
             "Stack type": st.column_config.TextColumn(),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download stack overview",
@@ -159,7 +159,7 @@ with tab_details:
             title="Stacks deployed per edge agent",
         )
         stack_chart.update_traces(hovertemplate="%{y}<br>Stacks: %{x}")
-        st.plotly_chart(style_plotly_figure(stack_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(stack_chart), width="stretch")
 
     status_summary = (
         stack_filtered[["endpoint_id", "endpoint_status"]]
@@ -178,7 +178,7 @@ with tab_details:
             hole=0.45,
         )
         status_chart.update_traces(textinfo="percent+label")
-        st.plotly_chart(style_plotly_figure(status_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(status_chart), width="stretch")
     else:
         st.info("No status information available for the selected agents.")
 
@@ -208,7 +208,7 @@ with tab_containers:
             title="Running containers per edge agent",
         )
         container_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
-        st.plotly_chart(style_plotly_figure(container_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(container_chart), width="stretch")
 
         treemap_source = (
             containers_filtered.assign(
@@ -227,7 +227,7 @@ with tab_containers:
                 title="Container footprint by environment, agent and image",
             )
             treemap.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
-            st.plotly_chart(style_plotly_figure(treemap), use_container_width=True)
+            st.plotly_chart(style_plotly_figure(treemap), width="stretch")
 
         ExportableDataFrame(
             "⬇️ Download container summary",

--- a/app/pages/2_Environment_Insights.py
+++ b/app/pages/2_Environment_Insights.py
@@ -131,7 +131,7 @@ if not endpoint_overview.empty:
         endpoint_overview.sort_values(
             ["environment_name", "endpoint_name"], na_position="last"
         ).reset_index(drop=True),
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download endpoint overview",
@@ -166,7 +166,7 @@ if not endpoint_overview.empty:
         load_scatter.update_traces(
             hovertemplate="%{hovertext}<br>Stacks: %{x}<br>Containers: %{y}"
         )
-        st.plotly_chart(style_plotly_figure(load_scatter), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(load_scatter), width="stretch")
 else:
     st.info("No stack information available for the selected filters.")
 
@@ -191,7 +191,7 @@ if not container_summary.empty:
         },
     )
     density_chart.update_layout(yaxis_title="Endpoint", xaxis_title="Containers")
-    st.plotly_chart(style_plotly_figure(density_chart), use_container_width=True)
+    st.plotly_chart(style_plotly_figure(density_chart), width="stretch")
 
     top_images = (
         containers_filtered.groupby(["environment_name", "image"], dropna=False)
@@ -216,7 +216,7 @@ if not container_summary.empty:
         )
         image_chart.update_layout(yaxis_title="Image", xaxis_title="Containers")
         image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
-        st.plotly_chart(style_plotly_figure(image_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(image_chart), width="stretch")
         ExportableDataFrame(
             "⬇️ Download top images",
             data=top_images,
@@ -266,7 +266,7 @@ if not container_summary.empty:
             color_discrete_sequence=px.colors.sequential.Agsunset,
         )
         age_chart.update_traces(hovertemplate="Age: %{x:.1f} days<br>Containers: %{y}")
-        st.plotly_chart(style_plotly_figure(age_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(age_chart), width="stretch")
 else:
     st.info("No container data available for the selected filters.")
 

--- a/app/pages/3_Running_Containers.py
+++ b/app/pages/3_Running_Containers.py
@@ -109,7 +109,7 @@ else:
             labels={"container_count": "Containers"},
         )
         state_chart.update_traces(hovertemplate="%{x}<br>Containers: %{y}")
-        st.plotly_chart(style_plotly_figure(state_chart), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(state_chart), width="stretch")
 
     container_display = containers_filtered.copy()
     created_series = pd.to_datetime(container_display["created_at"], errors="coerce", utc=True)
@@ -153,7 +153,7 @@ else:
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
             "Published ports": st.column_config.TextColumn(help="Public -> private port mapping"),
         },
-        use_container_width=True,
+        width="stretch",
     )
 
     ExportableDataFrame(

--- a/app/pages/4_Running_Images.py
+++ b/app/pages/4_Running_Images.py
@@ -123,7 +123,7 @@ else:
             "Running containers": st.column_config.NumberColumn(format="%d"),
             "Edge agents": st.column_config.NumberColumn(format="%d"),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download image summary",
@@ -145,7 +145,7 @@ else:
         title="Top images by running containers",
     )
     top_image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
-    st.plotly_chart(style_plotly_figure(top_image_chart), use_container_width=True)
+    st.plotly_chart(style_plotly_figure(top_image_chart), width="stretch")
 
     footprint_source = (
         containers_filtered.assign(image=lambda df: df["image"].fillna("Unknown image"))
@@ -161,5 +161,5 @@ else:
             title="Where images are running",
         )
         footprint.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
-        st.plotly_chart(style_plotly_figure(footprint), use_container_width=True)
+        st.plotly_chart(style_plotly_figure(footprint), width="stretch")
 

--- a/app/pages/5_Settings.py
+++ b/app/pages/5_Settings.py
@@ -12,6 +12,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         initialise_session_state,
         set_active_environment,
         set_saved_environments,
+        trigger_rerun,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
     from dashboard_state import (  # type: ignore[no-redef]
@@ -22,6 +23,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         initialise_session_state,
         set_active_environment,
         set_saved_environments,
+        trigger_rerun,
     )
 
 
@@ -29,10 +31,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 def rerun_app() -> None:
     """Trigger a Streamlit rerun across supported API versions."""
 
-    if hasattr(st, "rerun"):
-        st.rerun()
-    else:  # pragma: no cover - fallback for older Streamlit versions
-        st.experimental_rerun()
+    trigger_rerun()
 
 
 st.title("Settings")
@@ -103,7 +102,7 @@ with st.form("portainer_env_form"):
         "Verify SSL certificates",
         key="portainer_env_form_verify_ssl",
     )
-    submitted = st.form_submit_button("Save environment", use_container_width=True)
+    submitted = st.form_submit_button("Save environment", width="stretch")
 
 if submitted:
     name_value = st.session_state["portainer_env_form_name"].strip()

--- a/app/ui_helpers.py
+++ b/app/ui_helpers.py
@@ -97,6 +97,6 @@ class ExportableDataFrame:
             data=csv_bytes,
             file_name=self.filename,
             mime="text/csv",
-            use_container_width=True,
+            width="stretch",
         )
 


### PR DESCRIPTION
## Summary
- add a trigger_rerun helper so refresh actions work with the updated Streamlit rerun API
- replace deprecated use_container_width flags with width="stretch" on Streamlit widgets and charts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e137db54288333ae769cc3407f3101