### PR TITLE
Fix pandas fillna warnings in container dashboards

### DIFF
--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -137,7 +137,9 @@ else:
     container_display = container_display[existing_columns + remaining_columns]
     if "restart_count" in container_display.columns:
         container_display["restart_count"] = (
-            container_display["restart_count"].fillna(0).astype(int)
+            pd.to_numeric(container_display["restart_count"], errors="coerce")
+            .fillna(0)
+            .astype(int)
         )
 
     container_display = container_display.sort_values(


### PR DESCRIPTION
## Summary
- normalise container state and status sanitisation to avoid deprecated pandas downcasting behaviour
- coerce restart count data to numeric types before filling to maintain integer output without warnings
- ensure offline agent and summary displays use string-aware handling for missing data

## Testing
- python -m compileall app/pages/3_Container_Health.py app/pages/4_Workload_Explorer.py

------
https://chatgpt.com/codex/tasks/task_e_68e14182d96483339de4a34000340397