### PR TITLE
Ensure Lucerne theme persists across pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ if logo_path.exists():
         pass
 
 initialise_session_state()
+apply_lucerne_theme()
 apply_selected_environment()
 
 st.title("🚀 Streamlit Portainer Dashboard")

--- a/app/ui_helpers.py
+++ b/app/ui_helpers.py
@@ -23,10 +23,12 @@ def apply_lucerne_theme() -> None:
     """Inject the Canton of Lucerne visual styling into the Streamlit app."""
 
     theme_key = "_lucerne_theme_applied"
-    if st.session_state.get(theme_key):
-        return
-
-    st.session_state[theme_key] = True
+    # Track the number of times the theme has been injected mainly for debugging
+    # purposes, but always reapply the stylesheet. Streamlit rebuilds the page
+    # with every navigation or rerun which clears previously injected CSS, so
+    # skipping subsequent injections would cause the app to fall back to the
+    # default styling on secondary pages.
+    st.session_state[theme_key] = st.session_state.get(theme_key, 0) + 1
     st.markdown(
         """
         <style>


### PR DESCRIPTION
## Summary
- always reinject the Lucerne stylesheet on reruns so navigation between Streamlit pages retains the corporate branding
- apply the shared theme helper on the landing page so the home view matches the rest of the dashboard

## Testing
- streamlit run app/main.py --server.port 8501 --server.address 0.0.0.0


------
https://chatgpt.com/codex/tasks/task_e_68e1509aafec83338fe66766aeb5df90