### PR TITLE
Add docker compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ accent colour is overridden, so the interface remains readable in either mode.
 
 ## Usage
 
+### Run with Docker Compose
+1. Create a `.env` file (for example by copying `.env.example` if you have one) and populate it with the variables described above.
+2. Start the application:
+   ```bash
+   docker compose up -d
+   ```
+3. Visit http://localhost:8501 to access the dashboard. Any Portainer environments you add inside the app will be stored in the named `streamlit_portainer_envs` volume and remain available for future runs.
+
 ### Run with Docker
 1. Build the image (or pull it from your own registry):
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  streamlit-portainer-dashboard:
+    build: .
+    ports:
+      - "8501:8501"
+    env_file:
+      - .env
+    volumes:
+      - streamlit_portainer_envs:/app/.streamlit
+    restart: unless-stopped
+volumes:
+  streamlit_portainer_envs:
+    name: streamlit_portainer_envs


### PR DESCRIPTION
## Summary
- add a docker-compose.yml to build and run the dashboard with persisted Streamlit state
- document the docker compose workflow in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15c3aec088333a8f76f112587e6fd