### PR TITLE
Add authentication guard using environment-configured credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ The application is configured via environment variables:
 - `PORTAINER_API_URL` – Base URL of your Portainer instance (e.g. `https://portainer.example.com/api`).
 - `PORTAINER_API_KEY` – API key used for authentication.
 - `PORTAINER_VERIFY_SSL` – Optional. Set to `false` to disable TLS certificate verification when using self-signed certificates.
+- `DASHBOARD_USERNAME` – Username required to sign in to the dashboard UI.
+- `DASHBOARD_KEY` – Access key (password) required to sign in to the dashboard UI.
+
+Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
+operators can fix the configuration before exposing the dashboard.
 
 ### Theme
 
@@ -27,7 +32,8 @@ accent colour is overridden, so the interface remains readable in either mode.
 ## Usage
 
 ### Run with Docker Compose
-1. Create a `.env` file (for example by copying `.env.example` if you have one) and populate it with the variables described above.
+1. Create a `.env` file (for example by copying `.env.example` if you have one) and populate it with the variables described above,
+   including the mandatory `DASHBOARD_USERNAME` and `DASHBOARD_KEY` credentials.
 2. Start the application:
    ```bash
    docker compose up -d

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,64 @@
+"""Authentication utilities for the Streamlit dashboard."""
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+USERNAME_ENV_VAR = "DASHBOARD_USERNAME"
+KEY_ENV_VAR = "DASHBOARD_KEY"
+
+
+def _trigger_rerun() -> None:
+    """Trigger a Streamlit rerun using the available API."""
+    try:  # Streamlit < 1.27
+        st.experimental_rerun()
+    except AttributeError:  # pragma: no cover - Streamlit >= 1.27
+        st.rerun()  # type: ignore[attr-defined]
+
+
+def require_authentication() -> None:
+    """Prompt the user for credentials and block execution until authenticated."""
+    expected_username = os.getenv(USERNAME_ENV_VAR)
+    expected_key = os.getenv(KEY_ENV_VAR)
+
+    if not expected_username or not expected_key:
+        st.error(
+            "Dashboard credentials are not configured. Set both the "
+            f"`{USERNAME_ENV_VAR}` and `{KEY_ENV_VAR}` environment variables "
+            "before starting the app."
+        )
+        st.stop()
+
+    if st.session_state.get("authenticated"):
+        return
+
+    st.markdown("### 🔐 Sign in to the Portainer dashboard")
+    st.caption(
+        "Enter the credentials configured through the dashboard environment "
+        "variables."
+    )
+
+    error_message = st.session_state.get("auth_error")
+    if error_message:
+        st.error(error_message)
+
+    with st.form("dashboard-authentication"):
+        username = st.text_input("Username", placeholder="Dashboard username")
+        access_key = st.text_input(
+            "Access key",
+            placeholder="Dashboard access key",
+            type="password",
+        )
+        submitted = st.form_submit_button("Sign in")
+
+    if submitted:
+        if username == expected_username and access_key == expected_key:
+            st.session_state["authenticated"] = True
+            st.session_state.pop("auth_error", None)
+            _trigger_rerun()
+        else:
+            st.session_state["auth_error"] = "Invalid username or access key."
+            _trigger_rerun()
+
+    st.stop()

--- a/app/main.py
+++ b/app/main.py
@@ -5,12 +5,14 @@ import streamlit as st
 from dotenv import load_dotenv
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
     from app.dashboard_state import (  # type: ignore[import-not-found]
         apply_selected_environment,
         get_saved_environments,
         initialise_session_state,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
     from dashboard_state import (  # type: ignore[no-redef]
         apply_selected_environment,
         get_saved_environments,
@@ -21,6 +23,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 load_dotenv()
 
 st.set_page_config(page_title="Portainer Dashboard", layout="wide")
+
+require_authentication()
 
 initialise_session_state()
 apply_selected_environment()

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -5,6 +5,7 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -22,6 +23,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         style_plotly_figure,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -38,6 +40,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         render_page_header,
         style_plotly_figure,
     )
+
+require_authentication()
 
 render_page_header(
     "Fleet overview",

--- a/app/pages/2_Edge_and_Stack_Insights.py
+++ b/app/pages/2_Edge_and_Stack_Insights.py
@@ -6,6 +6,11 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
+
+try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -39,6 +44,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         render_page_header,
         style_plotly_figure,
     )
+
+require_authentication()
 
 render_page_header(
     "Edge agents & stacks",

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -6,6 +6,11 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
+
+try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -42,6 +47,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 
 
 RESTART_ALERT_THRESHOLD = 3
+
+require_authentication()
 
 render_page_header(
     "Container health",

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -5,6 +5,11 @@ import pandas as pd
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
+
+try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -38,6 +43,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         render_page_header,
         style_plotly_figure,
     )
+
+require_authentication()
 
 render_page_header(
     "Workload explorer",

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -5,6 +5,11 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
+
+try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -38,6 +43,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         render_page_header,
         style_plotly_figure,
     )
+
+require_authentication()
 
 render_page_header(
     "Image footprint",

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import require_authentication  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import require_authentication  # type: ignore[no-redef]
+
+try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         apply_selected_environment,
         clear_cached_data,
@@ -33,6 +38,8 @@ def rerun_app() -> None:
 
     trigger_rerun()
 
+
+require_authentication()
 
 st.title("Settings")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       - "8501:8501"
     env_file:
       - .env
+    environment:
+      DASHBOARD_USERNAME: ${DASHBOARD_USERNAME:?Set dashboard username}
+      DASHBOARD_KEY: ${DASHBOARD_KEY:?Set dashboard key}
     volumes:
       - streamlit_portainer_envs:/app/.streamlit
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add an authentication helper that prompts for credentials and halts execution until the configured environment username/key are provided
- gate the main entrypoint and every dashboard page behind the authentication check so unauthenticated users only see the login form
- surface the new credential variables in docker-compose and document how to configure them for deployments

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e26a66f0448333ad8fd8fbd58f00a2