### PR TITLE
Add configurable session timeout handling for dashboard auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The application is configured via environment variables:
 - `PORTAINER_VERIFY_SSL` – Optional. Set to `false` to disable TLS certificate verification when using self-signed certificates.
 - `DASHBOARD_USERNAME` – Username required to sign in to the dashboard UI.
 - `DASHBOARD_KEY` – Access key (password) required to sign in to the dashboard UI.
+- `DASHBOARD_SESSION_TIMEOUT_MINUTES` – Optional. Expire authenticated sessions after the specified number of minutes of inactivity. Omit or set to a non-positive value to disable the timeout.
 
 Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
 operators can fix the configuration before exposing the dashboard.

--- a/app/auth.py
+++ b/app/auth.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
+from functools import lru_cache
+from typing import Optional
 
 import streamlit as st
 
 USERNAME_ENV_VAR = "DASHBOARD_USERNAME"
 KEY_ENV_VAR = "DASHBOARD_KEY"
+SESSION_TIMEOUT_ENV_VAR = "DASHBOARD_SESSION_TIMEOUT_MINUTES"
 
 
 def _trigger_rerun() -> None:
@@ -15,6 +19,27 @@ def _trigger_rerun() -> None:
         st.experimental_rerun()
     except AttributeError:  # pragma: no cover - Streamlit >= 1.27
         st.rerun()  # type: ignore[attr-defined]
+
+
+@lru_cache(maxsize=1)
+def _get_session_timeout() -> Optional[timedelta]:
+    """Return the configured session timeout, if any."""
+    timeout_value = os.getenv(SESSION_TIMEOUT_ENV_VAR)
+    if timeout_value is None or not timeout_value.strip():
+        return None
+
+    try:
+        minutes = int(timeout_value)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(
+            "Invalid session timeout. Set "
+            f"`{SESSION_TIMEOUT_ENV_VAR}` to an integer number of minutes."
+        ) from exc
+
+    if minutes <= 0:
+        return None
+
+    return timedelta(minutes=minutes)
 
 
 def require_authentication() -> None:
@@ -30,8 +55,30 @@ def require_authentication() -> None:
         )
         st.stop()
 
+    try:
+        session_timeout = _get_session_timeout()
+    except ValueError as exc:
+        st.error(str(exc))
+        st.stop()
+
+    now = datetime.now(timezone.utc)
     if st.session_state.get("authenticated"):
-        return
+        last_active = st.session_state.get("last_active")
+        if not isinstance(last_active, datetime):
+            last_active = st.session_state.get("authenticated_at")
+
+        if session_timeout is not None and isinstance(last_active, datetime):
+            if now - last_active > session_timeout:
+                st.session_state.pop("authenticated", None)
+                st.session_state.pop("authenticated_at", None)
+                st.session_state.pop("last_active", None)
+                st.session_state["auth_error"] = "Session expired due to inactivity."
+            else:
+                st.session_state["last_active"] = now
+                return
+        else:
+            st.session_state["last_active"] = now
+            return
 
     st.markdown("### 🔐 Sign in to the Portainer dashboard")
     st.caption(
@@ -55,6 +102,8 @@ def require_authentication() -> None:
     if submitted:
         if username == expected_username and access_key == expected_key:
             st.session_state["authenticated"] = True
+            st.session_state["authenticated_at"] = now
+            st.session_state["last_active"] = now
             st.session_state.pop("auth_error", None)
             _trigger_rerun()
         else:


### PR DESCRIPTION
## Summary
- add optional `DASHBOARD_SESSION_TIMEOUT_MINUTES` environment variable and helper to parse the timeout value
- track authentication timestamps in the session and expire inactive sessions when a timeout is configured
- document the new timeout configuration option in the README

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e26eeb7e1c83338d5d60e7ab5f3f2b