### PR TITLE
Add sidebar logout control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The application is configured via environment variables:
 Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
 operators can fix the configuration before exposing the dashboard.
 
+After signing in, operators can use the persistent **Log out** button in the sidebar to clear their authentication session when
+they step away from the dashboard.
+
 ### Theme
 
 The default Streamlit theme is configured through `.streamlit/config.toml`. The dashboard ships with a

--- a/app/auth.py
+++ b/app/auth.py
@@ -62,3 +62,14 @@ def require_authentication() -> None:
             _trigger_rerun()
 
     st.stop()
+
+
+def render_logout_button() -> None:
+    """Display a logout control in the sidebar for authenticated users."""
+    if not st.session_state.get("authenticated"):
+        return
+
+    if st.sidebar.button("Log out", use_container_width=True):
+        for key in ("authenticated", "auth_error"):
+            st.session_state.pop(key, None)
+        _trigger_rerun()

--- a/app/main.py
+++ b/app/main.py
@@ -5,14 +5,20 @@ import streamlit as st
 from dotenv import load_dotenv
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
     from app.dashboard_state import (  # type: ignore[import-not-found]
         apply_selected_environment,
         get_saved_environments,
         initialise_session_state,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
     from dashboard_state import (  # type: ignore[no-redef]
         apply_selected_environment,
         get_saved_environments,
@@ -25,6 +31,7 @@ load_dotenv()
 st.set_page_config(page_title="Portainer Dashboard", layout="wide")
 
 require_authentication()
+render_logout_button()
 
 initialise_session_state()
 apply_selected_environment()

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -5,7 +5,10 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -23,7 +26,10 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         style_plotly_figure,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
@@ -42,6 +48,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     )
 
 require_authentication()
+render_logout_button()
 
 render_page_header(
     "Fleet overview",

--- a/app/pages/2_Edge_and_Stack_Insights.py
+++ b/app/pages/2_Edge_and_Stack_Insights.py
@@ -6,9 +6,15 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
@@ -46,6 +52,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     )
 
 require_authentication()
+render_logout_button()
 
 render_page_header(
     "Edge agents & stacks",

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -6,9 +6,15 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
@@ -49,6 +55,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 RESTART_ALERT_THRESHOLD = 3
 
 require_authentication()
+render_logout_button()
 
 render_page_header(
     "Container health",

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -5,9 +5,15 @@ import pandas as pd
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
@@ -45,6 +51,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     )
 
 require_authentication()
+render_logout_button()
 
 render_page_header(
     "Workload explorer",

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -5,9 +5,15 @@ import plotly.express as px
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
@@ -45,6 +51,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     )
 
 require_authentication()
+render_logout_button()
 
 render_page_header(
     "Image footprint",

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 import streamlit as st
 
 try:  # pragma: no cover - import shim for Streamlit runtime
-    from app.auth import require_authentication  # type: ignore[import-not-found]
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
-    from auth import require_authentication  # type: ignore[no-redef]
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
@@ -40,6 +46,7 @@ def rerun_app() -> None:
 
 
 require_authentication()
+render_logout_button()
 
 st.title("Settings")
 


### PR DESCRIPTION
## Summary
- add a reusable logout helper that clears authentication session state and reruns the app
- surface the logout button after authentication on the main view and each dashboard page
- document the new logout control in the README so operators know how to end their session

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e26eecf8008333823e002e9ad5b8f2