### PR TITLE
Add session timeout countdown and keep-alive warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing
 operators can fix the configuration before exposing the dashboard.
 
 After signing in, operators can use the persistent **Log out** button in the sidebar to clear their authentication session when
-they step away from the dashboard.
+they step away from the dashboard. When a session timeout is configured, the remaining time is shown in the sidebar so
+operators can always see how much longer the session will stay active. The dashboard automatically refreshes idle sessions every
+second to keep the countdown up to date. During the final 30 seconds a warning banner appears with a **Keep me logged in**
+button; clicking it immediately refreshes the activity timestamp and prevents the session from expiring.
 
 ### Theme
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit==1.50.0
+streamlit-autorefresh==1.0.1
 requests==2.32.5
 pandas==2.3.3
 plotly==6.3.0


### PR DESCRIPTION
## Summary
- show the remaining session time in the sidebar with a countdown warning and keep-alive button
- add an automatic refresh cadence that avoids extending idle sessions while keeping the timer current
- document the timeout experience and add the streamlit-autorefresh dependency

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e278917fe48333a251b6fcf0dcf383