### PR TITLE
Replace deprecated Streamlit width usage

### DIFF
--- a/app/dashboard_state.py
+++ b/app/dashboard_state.py
@@ -309,7 +309,7 @@ def render_sidebar_filters(
     """Render common sidebar controls and return the applied filters."""
 
     with st.sidebar:
-        if st.button("🔄 Refresh data", width="stretch"):
+        if st.button("🔄 Refresh data", use_container_width=True):
             clear_cached_data()
             trigger_rerun()
 

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -140,7 +140,7 @@ with tab_details:
             "Stack status": st.column_config.TextColumn(),
             "Stack type": st.column_config.TextColumn(),
         },
-        width="stretch",
+        use_container_width=True,
     )
     ExportableDataFrame(
         "⬇️ Download stack overview",

--- a/app/pages/2_Edge_and_Stack_Insights.py
+++ b/app/pages/2_Edge_and_Stack_Insights.py
@@ -145,7 +145,7 @@ if not endpoint_overview.empty:
         endpoint_overview.sort_values(
             ["environment_name", "endpoint_name"], na_position="last"
         ).reset_index(drop=True),
-        width="stretch",
+        use_container_width=True,
     )
     ExportableDataFrame(
         "⬇️ Download endpoint overview",

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -188,7 +188,9 @@ else:
 
 if not offline_agents.empty:
     st.subheader("Offline edge agents", divider="red")
-    st.dataframe(offline_agents.reset_index(drop=True), width="stretch")
+    st.dataframe(
+        offline_agents.reset_index(drop=True), use_container_width=True
+    )
     ExportableDataFrame(
         "⬇️ Download offline agent list",
         data=offline_agents,
@@ -258,7 +260,7 @@ if not problem_containers.empty:
             "Restarts": st.column_config.NumberColumn(format="%d"),
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
         },
-        width="stretch",
+        use_container_width=True,
     )
     ExportableDataFrame(
         "⬇️ Download attention list",
@@ -305,7 +307,7 @@ if not high_restart_containers.empty:
             "Restarts": st.column_config.NumberColumn(format="%d"),
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
         },
-        width="stretch",
+        use_container_width=True,
     )
     ExportableDataFrame(
         "⬇️ Download restart report",

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -179,7 +179,7 @@ else:
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
             "Published ports": st.column_config.TextColumn(help="Public -> private port mapping"),
         },
-        width="stretch",
+        use_container_width=True,
     )
 
     ExportableDataFrame(

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -137,7 +137,7 @@ else:
             "Running containers": st.column_config.NumberColumn(format="%d"),
             "Edge agents": st.column_config.NumberColumn(format="%d"),
         },
-        width="stretch",
+        use_container_width=True,
     )
     ExportableDataFrame(
         "⬇️ Download image summary",

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -130,11 +130,13 @@ with st.form("portainer_env_form"):
     )
     save_col, test_col = st.columns(2)
     with save_col:
-        submitted = st.form_submit_button("Save environment", width="stretch")
+        submitted = st.form_submit_button(
+            "Save environment", use_container_width=True
+        )
     with test_col:
         test_connection_clicked = st.form_submit_button(
             "Test connection",
-            width="stretch",
+            use_container_width=True,
         )
 
 name_value = st.session_state["portainer_env_form_name"].strip()

--- a/app/ui_helpers.py
+++ b/app/ui_helpers.py
@@ -126,6 +126,6 @@ class ExportableDataFrame:
             data=csv_bytes,
             file_name=self.filename,
             mime="text/csv",
-            width="stretch",
+            use_container_width=True,
         )
 


### PR DESCRIPTION
## Summary
- replace deprecated width="stretch" uses across dashboards with use_container_width=True
- ensure buttons, forms, and dataframes adopt the supported option

## Testing
- streamlit run app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e28b20921c83338ee1f9bdd15f7346