### PR TITLE
Replace deprecated Streamlit use_container_width flag

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -188,7 +188,7 @@ def render_logout_button() -> None:
     if not st.session_state.get("authenticated"):
         return
 
-    if st.sidebar.button("Log out", use_container_width=True):
+    if st.sidebar.button("Log out", width="stretch"):
         for key in ("authenticated", "auth_error"):
             st.session_state.pop(key, None)
         _trigger_rerun()

--- a/app/dashboard_state.py
+++ b/app/dashboard_state.py
@@ -312,7 +312,7 @@ def render_sidebar_filters(
     """Render common sidebar controls and return the applied filters."""
 
     with st.sidebar:
-        if st.button("🔄 Refresh data", use_container_width=True):
+        if st.button("🔄 Refresh data", width="stretch"):
             clear_cached_data()
             trigger_rerun()
 

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -140,7 +140,7 @@ with tab_details:
             "Stack status": st.column_config.TextColumn(),
             "Stack type": st.column_config.TextColumn(),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download stack overview",
@@ -171,7 +171,7 @@ with tab_details:
         )
         stack_chart.update_traces(hovertemplate="%{y}<br>Stacks: %{x}")
         st.plotly_chart(
-            style_plotly_figure(stack_chart), use_container_width=True
+            style_plotly_figure(stack_chart), width="stretch"
         )
 
     status_summary = (
@@ -192,7 +192,7 @@ with tab_details:
         )
         status_chart.update_traces(textinfo="percent+label")
         st.plotly_chart(
-            style_plotly_figure(status_chart), use_container_width=True
+            style_plotly_figure(status_chart), width="stretch"
         )
     else:
         st.info("No status information available for the selected agents.")
@@ -224,7 +224,7 @@ with tab_containers:
         )
         container_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
         st.plotly_chart(
-            style_plotly_figure(container_chart), use_container_width=True
+            style_plotly_figure(container_chart), width="stretch"
         )
 
         treemap_source = (
@@ -245,7 +245,7 @@ with tab_containers:
             )
             treemap.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
             st.plotly_chart(
-                style_plotly_figure(treemap), use_container_width=True
+                style_plotly_figure(treemap), width="stretch"
             )
 
         ExportableDataFrame(

--- a/app/pages/2_Edge_and_Stack_Insights.py
+++ b/app/pages/2_Edge_and_Stack_Insights.py
@@ -145,7 +145,7 @@ if not endpoint_overview.empty:
         endpoint_overview.sort_values(
             ["environment_name", "endpoint_name"], na_position="last"
         ).reset_index(drop=True),
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download endpoint overview",
@@ -181,7 +181,7 @@ if not endpoint_overview.empty:
             hovertemplate="%{hovertext}<br>Stacks: %{x}<br>Containers: %{y}"
         )
         st.plotly_chart(
-            style_plotly_figure(load_scatter), use_container_width=True
+            style_plotly_figure(load_scatter), width="stretch"
         )
 else:
     st.info("No stack information available for the selected filters.")
@@ -208,7 +208,7 @@ if not container_summary.empty:
     )
     density_chart.update_layout(yaxis_title="Endpoint", xaxis_title="Containers")
     st.plotly_chart(
-        style_plotly_figure(density_chart), use_container_width=True
+        style_plotly_figure(density_chart), width="stretch"
     )
 
     top_images = (
@@ -235,7 +235,7 @@ if not container_summary.empty:
         image_chart.update_layout(yaxis_title="Image", xaxis_title="Containers")
         image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
         st.plotly_chart(
-            style_plotly_figure(image_chart), use_container_width=True
+            style_plotly_figure(image_chart), width="stretch"
         )
         ExportableDataFrame(
             "⬇️ Download top images",
@@ -287,7 +287,7 @@ if not container_summary.empty:
         )
         age_chart.update_traces(hovertemplate="Age: %{x:.1f} days<br>Containers: %{y}")
         st.plotly_chart(
-            style_plotly_figure(age_chart), use_container_width=True
+            style_plotly_figure(age_chart), width="stretch"
         )
 else:
     st.info("No container data available for the selected filters.")

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -189,7 +189,7 @@ else:
 if not offline_agents.empty:
     st.subheader("Offline edge agents", divider="red")
     st.dataframe(
-        offline_agents.reset_index(drop=True), use_container_width=True
+        offline_agents.reset_index(drop=True), width="stretch"
     )
     ExportableDataFrame(
         "⬇️ Download offline agent list",
@@ -221,7 +221,7 @@ if not problem_summary.empty:
         title="Distribution of unhealthy containers",
     )
     issue_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
-    st.plotly_chart(style_plotly_figure(issue_chart), use_container_width=True)
+    st.plotly_chart(style_plotly_figure(issue_chart), width="stretch")
 
 if not problem_containers.empty:
     attention_display = problem_containers.copy()
@@ -260,7 +260,7 @@ if not problem_containers.empty:
             "Restarts": st.column_config.NumberColumn(format="%d"),
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download attention list",
@@ -307,7 +307,7 @@ if not high_restart_containers.empty:
             "Restarts": st.column_config.NumberColumn(format="%d"),
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download restart report",

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -124,7 +124,7 @@ else:
         )
         state_chart.update_traces(hovertemplate="%{x}<br>Containers: %{y}")
         st.plotly_chart(
-            style_plotly_figure(state_chart), use_container_width=True
+            style_plotly_figure(state_chart), width="stretch"
         )
 
     container_display = containers_filtered.copy()
@@ -179,7 +179,7 @@ else:
             "Created": st.column_config.TextColumn(help="Container creation timestamp"),
             "Published ports": st.column_config.TextColumn(help="Public -> private port mapping"),
         },
-        use_container_width=True,
+        width="stretch",
     )
 
     ExportableDataFrame(

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -137,7 +137,7 @@ else:
             "Running containers": st.column_config.NumberColumn(format="%d"),
             "Edge agents": st.column_config.NumberColumn(format="%d"),
         },
-        use_container_width=True,
+        width="stretch",
     )
     ExportableDataFrame(
         "⬇️ Download image summary",
@@ -160,7 +160,7 @@ else:
     )
     top_image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
     st.plotly_chart(
-        style_plotly_figure(top_image_chart), use_container_width=True
+        style_plotly_figure(top_image_chart), width="stretch"
     )
 
     footprint_source = (
@@ -178,6 +178,6 @@ else:
         )
         footprint.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
         st.plotly_chart(
-            style_plotly_figure(footprint), use_container_width=True
+            style_plotly_figure(footprint), width="stretch"
         )
 

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -131,12 +131,12 @@ with st.form("portainer_env_form"):
     save_col, test_col = st.columns(2)
     with save_col:
         submitted = st.form_submit_button(
-            "Save environment", use_container_width=True
+            "Save environment", width="stretch"
         )
     with test_col:
         test_connection_clicked = st.form_submit_button(
             "Test connection",
-            use_container_width=True,
+            width="stretch",
         )
 
 name_value = st.session_state["portainer_env_form_name"].strip()

--- a/app/ui_helpers.py
+++ b/app/ui_helpers.py
@@ -126,6 +126,6 @@ class ExportableDataFrame:
             data=csv_bytes,
             file_name=self.filename,
             mime="text/csv",
-            use_container_width=True,
+            width="stretch",
         )
 


### PR DESCRIPTION
## Summary
- replace deprecated use_container_width flag across dashboard controls with the new width argument
- ensure tables, charts, and buttons use width="stretch" to maintain full-width layouts

## Testing
- streamlit run app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e28e6321a08333a73669d18cb4b659