### PR TITLE
Fix Plotly chart warnings about deprecated keyword args

### DIFF
--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -171,7 +171,7 @@ with tab_details:
         )
         stack_chart.update_traces(hovertemplate="%{y}<br>Stacks: %{x}")
         st.plotly_chart(
-            style_plotly_figure(stack_chart), width="stretch"
+            style_plotly_figure(stack_chart), use_container_width=True
         )
 
     status_summary = (
@@ -192,7 +192,7 @@ with tab_details:
         )
         status_chart.update_traces(textinfo="percent+label")
         st.plotly_chart(
-            style_plotly_figure(status_chart), width="stretch"
+            style_plotly_figure(status_chart), use_container_width=True
         )
     else:
         st.info("No status information available for the selected agents.")
@@ -224,7 +224,7 @@ with tab_containers:
         )
         container_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
         st.plotly_chart(
-            style_plotly_figure(container_chart), width="stretch"
+            style_plotly_figure(container_chart), use_container_width=True
         )
 
         treemap_source = (
@@ -245,7 +245,7 @@ with tab_containers:
             )
             treemap.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
             st.plotly_chart(
-                style_plotly_figure(treemap), width="stretch"
+                style_plotly_figure(treemap), use_container_width=True
             )
 
         ExportableDataFrame(

--- a/app/pages/2_Edge_and_Stack_Insights.py
+++ b/app/pages/2_Edge_and_Stack_Insights.py
@@ -181,7 +181,7 @@ if not endpoint_overview.empty:
             hovertemplate="%{hovertext}<br>Stacks: %{x}<br>Containers: %{y}"
         )
         st.plotly_chart(
-            style_plotly_figure(load_scatter), width="stretch"
+            style_plotly_figure(load_scatter), use_container_width=True
         )
 else:
     st.info("No stack information available for the selected filters.")
@@ -208,7 +208,7 @@ if not container_summary.empty:
     )
     density_chart.update_layout(yaxis_title="Endpoint", xaxis_title="Containers")
     st.plotly_chart(
-        style_plotly_figure(density_chart), width="stretch"
+        style_plotly_figure(density_chart), use_container_width=True
     )
 
     top_images = (
@@ -235,7 +235,7 @@ if not container_summary.empty:
         image_chart.update_layout(yaxis_title="Image", xaxis_title="Containers")
         image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
         st.plotly_chart(
-            style_plotly_figure(image_chart), width="stretch"
+            style_plotly_figure(image_chart), use_container_width=True
         )
         ExportableDataFrame(
             "⬇️ Download top images",
@@ -287,7 +287,7 @@ if not container_summary.empty:
         )
         age_chart.update_traces(hovertemplate="Age: %{x:.1f} days<br>Containers: %{y}")
         st.plotly_chart(
-            style_plotly_figure(age_chart), width="stretch"
+            style_plotly_figure(age_chart), use_container_width=True
         )
 else:
     st.info("No container data available for the selected filters.")

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -221,7 +221,9 @@ if not problem_summary.empty:
         title="Distribution of unhealthy containers",
     )
     issue_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
-    st.plotly_chart(style_plotly_figure(issue_chart), width="stretch")
+    st.plotly_chart(
+        style_plotly_figure(issue_chart), use_container_width=True
+    )
 
 if not problem_containers.empty:
     attention_display = problem_containers.copy()

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -124,7 +124,7 @@ else:
         )
         state_chart.update_traces(hovertemplate="%{x}<br>Containers: %{y}")
         st.plotly_chart(
-            style_plotly_figure(state_chart), width="stretch"
+            style_plotly_figure(state_chart), use_container_width=True
         )
 
     container_display = containers_filtered.copy()

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -160,7 +160,7 @@ else:
     )
     top_image_chart.update_traces(hovertemplate="%{y}<br>Containers: %{x}")
     st.plotly_chart(
-        style_plotly_figure(top_image_chart), width="stretch"
+        style_plotly_figure(top_image_chart), use_container_width=True
     )
 
     footprint_source = (
@@ -178,6 +178,6 @@ else:
         )
         footprint.update_traces(hovertemplate="%{label}<br>Containers: %{value}")
         st.plotly_chart(
-            style_plotly_figure(footprint), width="stretch"
+            style_plotly_figure(footprint), use_container_width=True
         )
 


### PR DESCRIPTION
## Summary
- replace deprecated width keyword usage in Streamlit Plotly charts with the supported `use_container_width` flag to silence warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28fe90350833393a902ef6696a558