### PR TITLE
Add Dockerfile healthcheck for Streamlit app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app /app
 
 EXPOSE 8501
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD ["python", "-c", "import sys, urllib.request, urllib.error; url='http://127.0.0.1:8501/_stcore/health';\ntry:\n    sys.exit(0 if urllib.request.urlopen(url, timeout=5).getcode() == 200 else 1)\nexcept urllib.error.URLError:\n    sys.exit(1)\n"]
 ENTRYPOINT ["python", "-m", "streamlit", "run", "app/main.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
## Summary
- add a Docker HEALTHCHECK that queries Streamlit's built-in health endpoint to ensure the app is responsive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2910565848333ba7836d7ae9b30a1