### PR TITLE
Ensure Streamlit config directory is writable by nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,17 @@ RUN pip install --upgrade pip && \
 COPY .streamlit ./.streamlit
 COPY app ./app
 
+# Ensure the Streamlit configuration directory is writable by the runtime user
+RUN chown -R 65532:65532 ./.streamlit
+
 # --- Runtime stage (distroless 3.12) ---
 FROM gcr.io/distroless/python3-debian12:nonroot
 WORKDIR /app
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app /app
+# Guarantee the runtime user owns the Streamlit configuration directory
+COPY --from=builder --chown=65532:65532 /app/.streamlit /app/.streamlit
 
 EXPOSE 8501
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ accent colour is overridden, so the interface remains readable in either mode.
    docker build -t streamlit-portainer-dashboard .
    ```
 2. Create a `.env` file that contains the variables described above.
-3. Create a named volume so the app can persist the saved Portainer environments between runs:
+3. Create a named volume so the app can persist the saved Portainer environments between runs. Fresh volumes receive the
+   pre-populated `.streamlit` directory owned by the distroless `nonroot` user (UID/GID `65532`), so the container can write
+   the `portainer_environments.json` file without any manual permission changes:
    ```bash
    docker volume create streamlit_portainer_envs
    ```
@@ -66,6 +68,15 @@ accent colour is overridden, so the interface remains readable in either mode.
    ```
 5. Visit http://localhost:8501 to access the dashboard. Any Portainer environments you add inside the app will be stored in the mounted volume and remain available for future container runs.
 6. Use the sidebar controls to manage Portainer environments and filtering. The **Auto-refresh interval** slider can automatically reload data at 15–300 second intervals (set it to `Off`/`0` to disable auto-refresh).
+
+#### Repairing existing volumes
+
+If you created the `streamlit_portainer_envs` volume before this ownership fix, update its permissions so the runtime user can persist changes:
+
+```bash
+docker run --rm -v streamlit_portainer_envs:/app/.streamlit busybox \
+  chown -R 65532:65532 /app/.streamlit
+```
 
 ### Customising the storage location
 


### PR DESCRIPTION
## Summary
- ensure the Streamlit configuration directory is owned by UID/GID 65532 so the distroless runtime user can write portainer_environments.json
- document the automatic ownership on new volumes and how to repair existing volumes

## Testing
- not run (Docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2b7150d48833395a8d4d70e3f5c92