### PR TITLE
Add security assessment for reported CVEs

### DIFF
--- a/SECURITY_ASSESSMENT.md
+++ b/SECURITY_ASSESSMENT.md
@@ -1,0 +1,21 @@
+# Vulnerability Assessment
+
+## Scope
+This assessment evaluates whether the Streamlit Portainer Dashboard is exposed to the following CVEs reported by Trivy:
+
+- CVE-2023-45853
+- CVE-2025-7458
+
+## Findings
+### CVE-2023-45853 – MiniZip integer overflow
+- **Upstream issue**: The vulnerability affects the optional MiniZip component distributed alongside zlib through version 1.3, and projects that embed the vulnerable MiniZip sources such as `pyminizip`. Exploitation requires invoking `zipOpenNewFileInZip4_64` with attacker-controlled metadata.【e2462a†L1-L20】
+- **Application usage**: The dashboard's Python dependencies are limited to Streamlit, requests, pandas, plotly, PyYAML, python-dotenv, and a small Streamlit helper. None of these packages bundle or expose MiniZip or `pyminizip`, and the application code does not directly interface with zlib's MiniZip APIs.【F:requirements.txt†L1-L7】
+- **Result**: Not affected. The deployment does not include or call the vulnerable MiniZip code paths, so the CVE is not exploitable in this project.
+
+### CVE-2025-7458 – SQLite `KeyInfo` integer overflow
+- **Upstream issue**: The flaw exists in SQLite versions 3.39.2 through 3.41.1 when executing crafted `SELECT` statements containing large `ORDER BY` expression lists.【4393e4†L1-L9】 Exploitation requires an attacker to run arbitrary SQL against an affected SQLite engine.
+- **Application usage**: The dashboard relies on Streamlit and associated Python libraries and does not bundle or invoke SQLite. A repository-wide search shows no usage of SQLite APIs or SQL database integrations.【d62857†L1-L2】
+- **Result**: Not affected. Because the application neither ships SQLite nor executes SQL queries, the vulnerability cannot be triggered in this environment.
+
+## Conclusion
+Neither CVE-2023-45853 nor CVE-2025-7458 impacts the Streamlit Portainer Dashboard as presently configured. No remediation is required for this codebase. Continue to monitor base images for unrelated security updates as part of routine maintenance.


### PR DESCRIPTION
## Summary
- document the investigation into CVE-2023-45853 and CVE-2025-7458
- note that the project does not include the vulnerable MiniZip or SQLite components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36806024c83338af086e49985ce4e