### PR TITLE
Ensure edge endpoint status information is requested

### DIFF
--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -108,7 +108,8 @@ class PortainerClient:
             raise PortainerAPIError("Invalid JSON response from Portainer") from exc
 
     def list_edge_endpoints(self) -> List[Dict[str, object]]:
-        data = self._request("/endpoints", params={"edge": "true"})
+        params = {"edge": "true", "status": "true"}
+        data = self._request("/endpoints", params=params)
         if not isinstance(data, list):
             raise PortainerAPIError("Unexpected endpoints payload from Portainer")
         return data

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -1,0 +1,30 @@
+"""Tests for the Portainer client utilities."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.portainer_client import PortainerClient
+
+
+def test_list_edge_endpoints_requests_status(monkeypatch):
+    """The edge endpoint request should include status information."""
+
+    client = PortainerClient(base_url="https://portainer.example", api_key="token")
+
+    captured: dict[str, object] = {}
+
+    def fake_request(path: str, *, params=None):  # type: ignore[override]
+        captured["path"] = path
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    client.list_edge_endpoints()
+
+    assert captured["path"] == "/endpoints"
+    assert captured["params"] == {"edge": "true", "status": "true"}


### PR DESCRIPTION
## Summary
- request edge endpoint data from Portainer with the status flag so agent health values populate
- add a regression test to ensure the client requests status information when listing edge endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e37ca0a55c8333a68a04439fafdad0