### PR TITLE
Use placeholder LLM endpoint in docs and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ or the cache is invalidated. The cache is automatically cleared when operators s
 environment, press the **Refresh data** button in the sidebar, or modify the saved environment configuration. You
 can adjust or disable the behaviour through the new environment variables documented above.
 
+### LLM assistant
+
+The **LLM assistant** page lets you connect an OpenWebUI/Ollama deployment to the dashboard. Provide the chat
+completion endpoint (for example `https://llm.example.com/v1/chat/completions`), your API token and
+model name (such as `gpt-oss`). The page summarises the containers and stacks returned by Portainer—including any
+warnings—and sends that context along with your natural language question. This makes it possible to ask questions
+like “are there any containers that have issues and why?” directly from the dashboard. Responses are displayed in
+the UI and you can download the exact context shared with the model for auditing.
+
 ## Usage
 
 ### Run with Docker Compose

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -1,0 +1,313 @@
+"""LLM assistant page for querying Portainer data via OpenWebUI/Ollama."""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Mapping
+
+import pandas as pd
+import streamlit as st
+
+try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
+    from app.dashboard_state import (  # type: ignore[import-not-found]
+        ConfigurationError,
+        NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        fetch_portainer_data,
+        initialise_session_state,
+        load_configured_environment_settings,
+        render_sidebar_filters,
+    )
+    from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
+    from app.services.llm_client import (  # type: ignore[import-not-found]
+        LLMClient,
+        LLMClientError,
+    )
+    from app.ui_helpers import (  # type: ignore[import-not-found]
+        ExportableDataFrame,
+        render_page_header,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
+    from dashboard_state import (  # type: ignore[no-redef]
+        ConfigurationError,
+        NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        fetch_portainer_data,
+        initialise_session_state,
+        load_configured_environment_settings,
+        render_sidebar_filters,
+    )
+    from portainer_client import PortainerAPIError  # type: ignore[no-redef]
+    from services.llm_client import LLMClient, LLMClientError  # type: ignore[no-redef]
+    from ui_helpers import ExportableDataFrame, render_page_header  # type: ignore[no-redef]
+
+
+def _prepare_dataframe(df: pd.DataFrame, columns: Iterable[str]) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(columns=list(columns))
+    available_columns = [column for column in columns if column in df.columns]
+    if not available_columns:
+        return pd.DataFrame(columns=list(columns))
+    subset = df.loc[:, available_columns].copy()
+    return subset.fillna("")
+
+
+def _serialise_records(df: pd.DataFrame) -> list[dict[str, object]]:
+    if df.empty:
+        return []
+    serialised: list[dict[str, object]] = []
+    for record in df.to_dict(orient="records"):
+        cleaned: dict[str, object] = {}
+        for key, value in record.items():
+            if value in ("", None):
+                cleaned[key] = value
+            elif isinstance(value, (str, int, float, bool)):
+                cleaned[key] = value
+            else:
+                cleaned[key] = str(value)
+        serialised.append(cleaned)
+    return serialised
+
+
+require_authentication()
+render_logout_button()
+
+render_page_header(
+    "LLM assistant",
+    icon="🤖",
+    description=(
+        "Ask an Ollama/OpenWebUI hosted model about the Portainer data fetched by this dashboard."
+    ),
+)
+
+st.info(
+    "Provide the API endpoint and token for your OpenWebUI deployment. The assistant sends a concise "
+    "summary of the filtered Portainer containers and stacks as context for each question.",
+    icon="💡",
+)
+
+initialise_session_state()
+apply_selected_environment()
+
+try:
+    configured_environments = load_configured_environment_settings()
+except ConfigurationError as exc:
+    st.error(str(exc))
+    st.stop()
+except NoEnvironmentsConfiguredError:
+    st.warning(
+        "No Portainer environments configured. Visit the Settings page to add one.",
+        icon="ℹ️",
+    )
+    st.stop()
+
+try:
+    stack_data, container_data, warnings = fetch_portainer_data(
+        configured_environments, include_stopped=True
+    )
+except PortainerAPIError as exc:
+    st.error(f"Failed to load data from Portainer: {exc}")
+    st.stop()
+
+for warning in warnings:
+    st.warning(warning, icon="⚠️")
+
+filters = render_sidebar_filters(stack_data, container_data)
+stack_filtered = filters.stack_data
+containers_filtered = filters.container_data
+
+if stack_filtered.empty and containers_filtered.empty:
+    st.info("No Portainer data matched the current filters.", icon="ℹ️")
+
+
+DEFAULT_ENDPOINT = "https://llm.example.com/v1/chat/completions"
+
+with st.form("llm_query_form", enter_to_submit=False, clear_on_submit=False):
+    api_endpoint = st.text_input(
+        "OpenWebUI/Ollama API endpoint",
+        value=st.session_state.get("llm_api_endpoint", DEFAULT_ENDPOINT),
+        help=(
+            "Provide the full chat completion endpoint, for example "
+            "`https://llm.example.com/v1/chat/completions`."
+        ),
+    )
+    api_token = st.text_input(
+        "API token",
+        value=st.session_state.get("llm_api_token", ""),
+        type="password",
+        help="Use the `user:password` token generated by your OpenWebUI deployment.",
+    )
+    model_name = st.text_input(
+        "Model",
+        value=st.session_state.get("llm_model", "gpt-oss"),
+        help="Name of the model to query via OpenWebUI (e.g. `gpt-oss`).",
+    )
+    temperature = st.slider(
+        "Temperature",
+        min_value=0.0,
+        max_value=2.0,
+        value=float(st.session_state.get("llm_temperature", 0.3)),
+        step=0.1,
+        help="Higher values increase creativity; lower values make responses more deterministic.",
+    )
+    max_tokens = st.slider(
+        "Max tokens",
+        min_value=64,
+        max_value=2048,
+        value=int(st.session_state.get("llm_max_tokens", 512)),
+        step=64,
+        help="Maximum number of tokens to generate per response.",
+    )
+    verify_ssl = st.toggle(
+        "Verify TLS certificates",
+        value=bool(st.session_state.get("llm_verify_ssl", True)),
+        help="Disable this only when your OpenWebUI deployment uses a self-signed certificate.",
+    )
+    max_context_rows = st.slider(
+        "Max containers in context",
+        min_value=5,
+        max_value=200,
+        value=int(st.session_state.get("llm_max_context_rows", 50)),
+        step=5,
+        help="Limit the number of container rows shared with the LLM to keep prompts concise.",
+    )
+    question = st.text_area(
+        "Ask the LLM",
+        value=st.session_state.get(
+            "llm_last_question",
+            "Are there any containers reporting issues and what are the likely causes?",
+        ),
+        height=160,
+    )
+    submitted = st.form_submit_button("Ask the LLM", use_container_width=True)
+
+st.session_state["llm_api_endpoint"] = api_endpoint
+st.session_state["llm_api_token"] = api_token
+st.session_state["llm_model"] = model_name
+st.session_state["llm_temperature"] = temperature
+st.session_state["llm_max_tokens"] = max_tokens
+st.session_state["llm_verify_ssl"] = verify_ssl
+st.session_state["llm_max_context_rows"] = max_context_rows
+
+container_columns = (
+    "environment_name",
+    "endpoint_name",
+    "container_name",
+    "state",
+    "status",
+    "restart_count",
+    "image",
+    "ports",
+)
+stack_columns = (
+    "environment_name",
+    "endpoint_name",
+    "stack_name",
+    "stack_status",
+    "stack_type",
+)
+
+container_context = _prepare_dataframe(containers_filtered, container_columns)
+stack_context = _prepare_dataframe(stack_filtered, stack_columns)
+
+context_notice = False
+if len(container_context) > max_context_rows:
+    container_context = container_context.head(max_context_rows)
+    context_notice = True
+
+context_payload: dict[str, object] = {}
+if not container_context.empty:
+    context_payload["containers"] = _serialise_records(container_context)
+if not stack_context.empty:
+    context_payload["stacks"] = _serialise_records(stack_context.head(50))
+if warnings:
+    context_payload["warnings"] = list(warnings)
+
+if context_notice:
+    st.caption(
+        "Only the first %s containers are included in the LLM context to keep the prompt concise."
+        % max_context_rows
+    )
+
+st.subheader("Container context shared with the LLM")
+ExportableDataFrame(
+    "Download container context",
+    container_context,
+    "portainer_container_context.csv",
+).render_download_button()
+st.dataframe(container_context, use_container_width=True, hide_index=True)
+
+if not stack_context.empty:
+    st.subheader("Stack context shared with the LLM")
+    ExportableDataFrame(
+        "Download stack context",
+        stack_context,
+        "portainer_stack_context.csv",
+    ).render_download_button()
+    st.dataframe(stack_context, use_container_width=True, hide_index=True)
+
+displayed_response = False
+
+if submitted:
+    question_clean = question.strip()
+    endpoint_clean = api_endpoint.strip()
+    if not endpoint_clean:
+        st.error("Please provide the OpenWebUI/Ollama API endpoint.")
+    elif not question_clean:
+        st.warning("Enter a question for the LLM before submitting.", icon="ℹ️")
+    elif not context_payload:
+        st.warning(
+            "There is no Portainer data to send to the LLM. Adjust the filters or refresh the data.",
+            icon="ℹ️",
+        )
+    else:
+        context_json = json.dumps(context_payload, indent=2, ensure_ascii=False)
+        system_prompt = (
+            "You are a helpful assistant that analyses Portainer container telemetry to help operators "
+            "understand their Docker environments. Base your answer strictly on the provided context."
+        )
+        messages: list[Mapping[str, object]] = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": (
+                    f"Question: {question_clean}\n\n"
+                    "Context (JSON):\n"
+                    f"{context_json}"
+                ),
+            },
+        ]
+        client = LLMClient(
+            base_url=endpoint_clean,
+            token=api_token or None,
+            model=model_name.strip() or "gpt-oss",
+            verify_ssl=verify_ssl,
+        )
+        with st.spinner("Querying the LLM..."):
+            try:
+                answer = client.chat(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            except LLMClientError as exc:
+                st.error(f"LLM request failed: {exc}")
+            else:
+                st.session_state["llm_last_question"] = question_clean
+                st.session_state["llm_last_answer"] = answer
+                st.markdown("### LLM response")
+                st.markdown(answer)
+                displayed_response = True
+
+if not displayed_response and (last_answer := st.session_state.get("llm_last_answer")):
+    st.markdown("### Most recent response")
+    st.markdown(last_answer)
+

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,4 @@
+"""Service layer helpers for the Streamlit dashboard."""
+
+__all__ = ["llm_client"]
+

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,0 +1,116 @@
+"""Client helpers for interacting with OpenWebUI/Ollama compatible APIs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+import requests
+
+__all__ = ["LLMClient", "LLMClientError"]
+
+
+class LLMClientError(RuntimeError):
+    """Raised when an LLM request fails."""
+
+
+def _normalise_messages(messages: Iterable[Mapping[str, object]]) -> list[dict[str, object]]:
+    normalised: list[dict[str, object]] = []
+    for message in messages:
+        role = str(message.get("role", ""))
+        content = message.get("content", "")
+        normalised.append({"role": role, "content": content})
+    return normalised
+
+
+def _extract_response_text(payload: Mapping[str, object]) -> str:
+    choices = payload.get("choices")
+    if not isinstance(choices, Sequence) or not choices:
+        raise LLMClientError("LLM API response did not include any choices")
+    first_choice = choices[0]
+    if isinstance(first_choice, Mapping):
+        message = first_choice.get("message")
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content.strip()
+        content = first_choice.get("text")
+        if isinstance(content, str):
+            return content.strip()
+    if isinstance(first_choice, str):
+        return first_choice.strip()
+    raise LLMClientError("LLM API response did not contain text output")
+
+
+@dataclass
+class LLMClient:
+    """Lightweight client for OpenAI-compatible LLM endpoints."""
+
+    base_url: str
+    token: str | None = None
+    model: str = "gpt-oss"
+    timeout: tuple[float, float] = (10.0, 60.0)
+    verify_ssl: bool = True
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token.strip()}"
+        return headers
+
+    def _payload(
+        self,
+        messages: Iterable[Mapping[str, object]],
+        *,
+        temperature: float,
+        max_tokens: int,
+        stream: bool,
+        extra_options: Mapping[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "model": self.model,
+            "messages": _normalise_messages(messages),
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": stream,
+        }
+        if extra_options:
+            payload.update(dict(extra_options))
+        return payload
+
+    def chat(
+        self,
+        messages: Iterable[Mapping[str, object]],
+        *,
+        temperature: float = 0.2,
+        max_tokens: int = 512,
+        stream: bool = False,
+        extra_options: Mapping[str, object] | None = None,
+    ) -> str:
+        """Send a chat completion request and return the first response text."""
+
+        payload = self._payload(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=stream,
+            extra_options=extra_options,
+        )
+        try:
+            response = requests.post(
+                self.base_url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            raise LLMClientError(f"Failed to query LLM API: {exc}") from exc
+        try:
+            data = response.json()
+        except ValueError as exc:  # pragma: no cover - unexpected payload
+            raise LLMClientError("Invalid JSON response from LLM API") from exc
+        if not isinstance(data, Mapping):
+            raise LLMClientError("Unexpected LLM API response format")
+        return _extract_response_text(data)
+

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.llm_client import LLMClient, LLMClientError
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict[str, object]):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - nothing to do
+        return
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def test_chat_returns_first_message(monkeypatch):
+    """The client should extract the first message text from the response."""
+
+    captured: dict[str, object] = {}
+
+    def fake_post(url, *, headers=None, json=None, timeout=None, verify=None):  # type: ignore[override]
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        captured["verify"] = verify
+        payload = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "Hello from the model."},
+                }
+            ]
+        }
+        return _DummyResponse(payload)
+
+    monkeypatch.setattr("app.services.llm_client.requests.post", fake_post)
+
+    client = LLMClient(
+        base_url="https://example.test/v1/chat/completions",
+        token="api-token",
+        model="gpt-oss",
+        verify_ssl=False,
+    )
+
+    response = client.chat([{"role": "user", "content": "Ping"}], temperature=0.5, max_tokens=256)
+
+    assert response == "Hello from the model."
+    assert captured["url"] == "https://example.test/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer api-token"
+    assert captured["json"]["temperature"] == 0.5
+    assert captured["json"]["max_tokens"] == 256
+    assert captured["verify"] is False
+
+
+def test_chat_raises_for_missing_choices(monkeypatch):
+    """An invalid payload should raise an ``LLMClientError``."""
+
+    def fake_post(*args, **kwargs):  # type: ignore[override]
+        return _DummyResponse({"choices": []})
+
+    monkeypatch.setattr("app.services.llm_client.requests.post", fake_post)
+
+    client = LLMClient(base_url="https://example.test/api")
+
+    with pytest.raises(LLMClientError):
+        client.chat([{"role": "user", "content": "Ping"}])
+


### PR DESCRIPTION
## Summary
- replace references to an internal OpenWebUI endpoint with a generic placeholder URL in the assistant page
- update the README example endpoint to match the placeholder used in the UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e38397fc4483339082c730b757c68c