### PR TITLE
Fix default cache directory location

### DIFF
--- a/app/environment_cache.py
+++ b/app/environment_cache.py
@@ -72,7 +72,7 @@ def _cache_directory() -> Path:
     override = os.getenv(_CACHE_DIR_ENV_VAR)
     if override:
         return Path(override).expanduser()
-    return Path(__file__).resolve().parent / ".streamlit" / "cache"
+    return Path(__file__).resolve().parent.parent / ".streamlit" / "cache"
 
 
 def _cache_path(key: str) -> Path:


### PR DESCRIPTION
## Summary
- point the default persistent cache directory to the application root `.streamlit/cache`
- keep support for overriding the cache location via `PORTAINER_CACHE_DIR`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3855f9be083339cc7c38e0c7a934e