### PR TITLE
Add stack image status view to image footprint dashboard

### DIFF
--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -1,6 +1,10 @@
 """Image footprint dashboard."""
 from __future__ import annotations
 
+import re
+from typing import Sequence
+
+import pandas as pd
 import plotly.express as px
 import streamlit as st
 
@@ -25,7 +29,10 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         load_configured_environment_settings,
         render_sidebar_filters,
     )
-    from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
+    from app.portainer_client import (  # type: ignore[import-not-found]
+        PortainerAPIError,
+        PortainerClient,
+    )
     from app.ui_helpers import (  # type: ignore[import-not-found]
         ExportableDataFrame,
         render_kpi_row,
@@ -42,13 +49,248 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_configured_environment_settings,
         render_sidebar_filters,
     )
-    from portainer_client import PortainerAPIError  # type: ignore[no-redef]
+    from portainer_client import (  # type: ignore[no-redef]
+        PortainerAPIError,
+        PortainerClient,
+    )
     from ui_helpers import (  # type: ignore[no-redef]
         ExportableDataFrame,
         render_kpi_row,
         render_page_header,
         style_plotly_figure,
     )
+
+
+_IMAGE_NAME_PATTERN = re.compile(
+    r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*(?::[A-Za-z0-9_.-]+)?(?:@sha256:[0-9a-f]{64})?"
+)
+_TRUE_STRINGS = {
+    "true",
+    "yes",
+    "1",
+    "updated",
+    "up to date",
+    "up-to-date",
+    "uptodate",
+    "latest",
+    "new",
+}
+_FALSE_STRINGS = {
+    "false",
+    "0",
+    "no",
+    "outdated",
+    "out of date",
+    "out-of-date",
+    "stale",
+    "needs update",
+    "needs-update",
+    "update available",
+    "updates available",
+    "not new",
+    "obsolete",
+}
+_IMAGE_KEYS = {
+    "image",
+    "imagename",
+    "image_name",
+    "name",
+    "tag",
+    "imagetag",
+    "repository",
+    "repo",
+    "repotag",
+    "current",
+    "currentimage",
+    "current_image",
+}
+
+
+def _coerce_boolish(value: object) -> bool | None:
+    """Best-effort conversion of Portainer status values to booleans."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        normalised = lowered.replace("-", " ")
+        if normalised in _TRUE_STRINGS:
+            return True
+        if normalised in _FALSE_STRINGS:
+            return False
+    return None
+
+
+def _normalise_image_name(value: object) -> str | None:
+    """Attempt to coerce ``value`` into a container image reference."""
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned or " " in cleaned:
+            return None
+        lowered = cleaned.lower()
+        if lowered in _TRUE_STRINGS or lowered in _FALSE_STRINGS:
+            return None
+        if not any(sep in cleaned for sep in (":", "/", "@", ".")):
+            return None
+        return cleaned
+    if isinstance(value, dict):
+        for key in ("Image", "image", "Name", "name", "RepoTag", "repoTag", "RepoTags", "repoTags", "Tag", "tag"):
+            if key in value:
+                candidate = _normalise_image_name(value[key])
+                if candidate:
+                    return candidate
+        return None
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            candidate = _normalise_image_name(item)
+            if candidate:
+                return candidate
+    return None
+
+
+def _extract_outdated_images(payload: object) -> list[str]:
+    """Return image names identified as outdated within ``payload``."""
+
+    images: set[str] = set()
+
+    def _walk(obj: object, flagged: bool = False) -> None:
+        if isinstance(obj, dict):
+            local_flag = flagged
+            for key, value in obj.items():
+                key_lower = str(key).lower()
+                if key_lower in {"isnew", "new", "fresh", "uptodate", "up_to_date", "up-to-date"}:
+                    coerced = _coerce_boolish(value)
+                    if coerced is not None:
+                        local_flag = not coerced
+                elif key_lower in {"status", "state", "result"}:
+                    coerced = _coerce_boolish(value)
+                    if coerced is not None:
+                        local_flag = not coerced
+                elif key_lower in {"outdated", "outdatedimages", "imagesrequiringupdate", "imagesrequiringupdates"}:
+                    _walk(value, flagged=True)
+                    continue
+
+                if key_lower in _IMAGE_KEYS:
+                    candidate = _normalise_image_name(value)
+                    if candidate and (local_flag or flagged):
+                        images.add(candidate)
+
+                if isinstance(value, (dict, list, tuple, set)):
+                    _walk(value, flagged=local_flag)
+                elif local_flag:
+                    candidate = _normalise_image_name(value)
+                    if candidate:
+                        images.add(candidate)
+        elif isinstance(obj, (list, tuple, set)):
+            for item in obj:
+                _walk(item, flagged=flagged)
+        elif isinstance(obj, str) and flagged:
+            for candidate in _IMAGE_NAME_PATTERN.findall(obj):
+                cleaned = candidate.strip()
+                if cleaned:
+                    images.add(cleaned)
+
+    _walk(payload, flagged=False)
+
+    if not images and isinstance(payload, dict):
+        message = payload.get("Message")
+        if isinstance(message, str):
+            for candidate in _IMAGE_NAME_PATTERN.findall(message):
+                cleaned = candidate.strip()
+                if cleaned:
+                    images.add(cleaned)
+
+    return sorted(images)
+
+
+@st.cache_data(show_spinner=False)
+def load_stack_image_statuses(
+    environments: Sequence[object],
+    stack_requests: Sequence[tuple[str, int, str]],
+) -> tuple[pd.DataFrame, list[str]]:
+    """Fetch image status information for the provided stacks."""
+
+    env_map = {env.name: env for env in environments}
+    clients: dict[str, PortainerClient] = {}
+    records: list[dict[str, object]] = []
+    warnings: list[str] = []
+
+    for env_name, stack_id, stack_name in stack_requests:
+        environment = env_map.get(env_name)
+        if environment is None:
+            warnings.append(
+                f"[{env_name}] Stack '{stack_name}' is not associated with a configured environment."
+            )
+            continue
+
+        client = clients.get(env_name)
+        if client is None:
+            client = PortainerClient(
+                base_url=environment.api_url,
+                api_key=environment.api_key,
+                verify_ssl=environment.verify_ssl,
+            )
+            clients[env_name] = client
+
+        try:
+            payload = client.get_stack_image_status(stack_id)
+        except PortainerAPIError as exc:
+            warnings.append(
+                f"[{env_name}] Failed to load image status for stack '{stack_name}' (ID {stack_id}): {exc}"
+            )
+            continue
+
+        status = None
+        message = None
+        if isinstance(payload, dict):
+            status = payload.get("Status")
+            message = payload.get("Message")
+
+        outdated_images = _extract_outdated_images(payload)
+
+        if outdated_images:
+            for image_name in outdated_images:
+                records.append(
+                    {
+                        "environment_name": env_name,
+                        "stack_id": stack_id,
+                        "stack_name": stack_name,
+                        "image_name": image_name,
+                        "status": status,
+                        "message": message,
+                    }
+                )
+        elif isinstance(status, str) and status.lower() in {"outdated", "update available", "updates available"}:
+            records.append(
+                {
+                    "environment_name": env_name,
+                    "stack_id": stack_id,
+                    "stack_name": stack_name,
+                    "image_name": None,
+                    "status": status,
+                    "message": message,
+                }
+            )
+
+    columns = [
+        "environment_name",
+        "stack_id",
+        "stack_name",
+        "image_name",
+        "status",
+        "message",
+    ]
+
+    if records:
+        status_df = pd.DataFrame.from_records(records, columns=columns)
+    else:
+        status_df = pd.DataFrame(columns=columns)
+
+    return status_df, warnings
+
 
 require_authentication()
 render_logout_button()
@@ -180,4 +422,89 @@ else:
         st.plotly_chart(
             style_plotly_figure(footprint), use_container_width=True
         )
+
+st.subheader("Stacks with outdated images")
+
+stack_overview = filters.stack_data
+if stack_overview.empty or "stack_id" not in stack_overview.columns:
+    st.info("No stack assignments were returned by Portainer to check image status.")
+else:
+    stack_candidates = (
+        stack_overview[["environment_name", "stack_id", "stack_name"]]
+        .dropna(subset=["environment_name", "stack_id"])
+        .copy()
+    )
+    stack_candidates["stack_id"] = pd.to_numeric(
+        stack_candidates["stack_id"], errors="coerce"
+    )
+    stack_candidates = stack_candidates.dropna(subset=["stack_id"])
+
+    if stack_candidates.empty:
+        st.info("No stack identifiers are available to query image status.")
+    else:
+        unique_requests = []
+        for row in (
+            stack_candidates.drop_duplicates(subset=["environment_name", "stack_id"])
+            .itertuples(index=False)
+        ):
+            env_name = str(row.environment_name)
+            stack_id_value = int(row.stack_id)
+            raw_name = getattr(row, "stack_name", None)
+            stack_name = (
+                str(raw_name).strip()
+                if raw_name is not None and str(raw_name).strip()
+                else f"Stack {stack_id_value}"
+            )
+            unique_requests.append((env_name, stack_id_value, stack_name))
+
+        if not unique_requests:
+            st.info("No stack identifiers are available to query image status.")
+        else:
+            with st.spinner("Checking stack image status via Portainer..."):
+                image_status_df, image_status_warnings = load_stack_image_statuses(
+                    tuple(configured_environments),
+                    tuple(unique_requests),
+                )
+
+            for warning in image_status_warnings:
+                st.warning(warning, icon="⚠️")
+
+            if image_status_df.empty:
+                st.success("All monitored stacks are reporting the newest images available.")
+            else:
+                display_df = image_status_df.copy()
+                display_df["Environment"] = display_df["environment_name"]
+                display_df["Stack"] = display_df["stack_name"].fillna("")
+                empty_stack_mask = display_df["Stack"].str.strip() == ""
+                display_df.loc[empty_stack_mask, "Stack"] = display_df.loc[
+                    empty_stack_mask, "stack_id"
+                ].apply(lambda value: f"Stack {int(value)}" if pd.notna(value) else "Unknown stack")
+                display_df["Image"] = display_df["image_name"].fillna("(not specified)")
+                display_df["Status"] = display_df["status"].fillna("outdated")
+                display_df["Details"] = display_df["message"].fillna("")
+
+                ordered = (
+                    display_df[
+                        ["Environment", "Stack", "Image", "Status", "Details"]
+                    ]
+                    .sort_values(["Environment", "Stack", "Image"], ignore_index=True)
+                )
+
+                st.dataframe(
+                    ordered,
+                    column_config={
+                        "Environment": st.column_config.TextColumn(),
+                        "Stack": st.column_config.TextColumn(),
+                        "Image": st.column_config.TextColumn(),
+                        "Status": st.column_config.TextColumn(),
+                        "Details": st.column_config.TextColumn(),
+                    },
+                    width="stretch",
+                )
+
+                ExportableDataFrame(
+                    "⬇️ Download outdated image list",
+                    data=image_status_df,
+                    filename="portainer_outdated_stack_images.csv",
+                ).render_download_button()
 

--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -153,6 +153,14 @@ class PortainerClient:
             raise PortainerAPIError("Unexpected containers payload from Portainer")
         return data
 
+    def get_stack_image_status(self, stack_id: int) -> object:
+        """Return the image status payload for the specified stack."""
+
+        data = self._request(f"/stacks/{stack_id}/images_status")
+        if not isinstance(data, (dict, list)):
+            raise PortainerAPIError("Unexpected stack image status payload from Portainer")
+        return data
+
 
 def normalise_endpoint_stacks(
     endpoints: Iterable[Dict[str, object]],

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -28,3 +28,24 @@ def test_list_edge_endpoints_requests_status(monkeypatch):
 
     assert captured["path"] == "/endpoints"
     assert captured["params"] == {"edge": "true", "status": "true"}
+
+
+def test_get_stack_image_status(monkeypatch):
+    """Stack image status requests should hit the expected endpoint."""
+
+    client = PortainerClient(base_url="https://portainer.example", api_key="token")
+
+    captured: dict[str, object] = {}
+
+    def fake_request(path: str, *, params=None):  # type: ignore[override]
+        captured["path"] = path
+        captured["params"] = params
+        return {"Status": "updated"}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    payload = client.get_stack_image_status(42)
+
+    assert captured["path"] == "/stacks/42/images_status"
+    assert captured["params"] is None
+    assert payload == {"Status": "updated"}


### PR DESCRIPTION
## Summary
- call Portainer's stack image status endpoint and expose the results on the image footprint dashboard
- parse stack status payloads to list outdated images and provide an exportable table for operators
- add a Portainer client helper and regression test for the new API call

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3930b22b883338f47b2a809fa3631