### PR TITLE
Add Portainer backup management workflow

### DIFF
--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -1,0 +1,81 @@
+"""Helpers for creating and storing Portainer backups."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import re
+from pathlib import Path
+from typing import Mapping, Optional
+
+try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.portainer_client import PortainerClient  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from portainer_client import PortainerClient  # type: ignore[no-redef]
+
+__all__ = ["backup_directory", "create_environment_backup"]
+
+_BACKUP_DIR_ENV_VAR = "PORTAINER_BACKUP_DIR"
+
+
+def backup_directory() -> Path:
+    """Return the directory used to persist Portainer backups."""
+
+    override = os.getenv(_BACKUP_DIR_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+    return Path(__file__).resolve().parent.parent / ".streamlit" / "backups"
+
+
+def _ensure_backup_directory() -> Path:
+    directory = backup_directory()
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _sanitise_component(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+    return cleaned.strip("-_") or "portainer"
+
+
+def _unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    suffix = "".join(path.suffixes)
+    if suffix:
+        stem = path.name[: -len(suffix)]
+    else:
+        stem = path.name
+    counter = 2
+    candidate = path
+    while candidate.exists():
+        candidate = path.with_name(f"{stem.rstrip('_')}_{counter}{suffix}")
+        counter += 1
+    return candidate
+
+
+def create_environment_backup(
+    environment: Mapping[str, object], *, password: Optional[str] = None
+) -> Path:
+    """Create a backup for ``environment`` and store it on disk."""
+
+    api_url = str(environment.get("api_url", "")).strip()
+    api_key = str(environment.get("api_key", "")).strip()
+    if not api_url or not api_key:
+        raise ValueError("Environment is missing an API URL or API key")
+    verify_ssl = bool(environment.get("verify_ssl", True))
+    client = PortainerClient(base_url=api_url, api_key=api_key, verify_ssl=verify_ssl)
+    payload, filename = client.create_backup(password=password)
+    directory = _ensure_backup_directory()
+    env_name = str(environment.get("name", "portainer")) or "portainer"
+    prefix = _sanitise_component(env_name)
+    timestamp = _dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    if filename:
+        base_name = Path(filename).name
+    else:
+        base_name = f"portainer-backup-{timestamp}.tar.gz"
+    backup_name = f"{prefix}_{base_name}" if prefix else base_name
+    destination = directory / backup_name
+    destination = _unique_path(destination)
+    destination.write_bytes(payload)
+    return destination

--- a/tests/test_backup_service.py
+++ b/tests/test_backup_service.py
@@ -1,0 +1,79 @@
+"""Tests for the Portainer backup service helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import backup as backup_service
+
+
+def test_create_environment_backup_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("PORTAINER_BACKUP_DIR", str(tmp_path))
+
+    environment = {
+        "name": "Production Cluster",
+        "api_url": "https://portainer.example/api",
+        "api_key": "token",
+        "verify_ssl": False,
+    }
+
+    class DummyClient:
+        def __init__(self, *, base_url, api_key, verify_ssl):
+            self.base_url = base_url
+            self.api_key = api_key
+            self.verify_ssl = verify_ssl
+
+        def create_backup(self, *, password=None):
+            assert password == "s3cret"
+            return b"archive-bytes", "portainer-backup.tar.gz"
+
+    monkeypatch.setattr(backup_service, "PortainerClient", DummyClient)
+
+    backup_path = backup_service.create_environment_backup(
+        environment, password="s3cret"
+    )
+
+    assert backup_path.parent == tmp_path
+    assert backup_path.read_bytes() == b"archive-bytes"
+    assert backup_path.name.startswith("Production-Cluster_")
+
+
+def test_create_environment_backup_requires_credentials():
+    with pytest.raises(ValueError):
+        backup_service.create_environment_backup({"name": "Broken"})
+
+
+def test_create_environment_backup_generates_unique_names(tmp_path, monkeypatch):
+    monkeypatch.setenv("PORTAINER_BACKUP_DIR", str(tmp_path))
+
+    environment = {
+        "name": "Edge",
+        "api_url": "https://portainer.example/api",
+        "api_key": "token",
+    }
+
+    class DummyClient:
+        call_count = 0
+
+        def __init__(self, *, base_url, api_key, verify_ssl=True):
+            self.base_url = base_url
+            self.api_key = api_key
+            self.verify_ssl = verify_ssl
+
+        def create_backup(self, *, password=None):
+            DummyClient.call_count += 1
+            return b"payload", "portainer-backup.tar.gz"
+
+    monkeypatch.setattr(backup_service, "PortainerClient", DummyClient)
+
+    first = backup_service.create_environment_backup(environment)
+    second = backup_service.create_environment_backup(environment)
+
+    assert first != second
+    assert first.exists() and second.exists()
+    assert second.name != first.name

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+import requests
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.portainer_client import PortainerClient
+from app import portainer_client
+from app.portainer_client import PortainerAPIError, PortainerClient
 
 
 def test_list_edge_endpoints_requests_status(monkeypatch):
@@ -28,3 +32,50 @@ def test_list_edge_endpoints_requests_status(monkeypatch):
 
     assert captured["path"] == "/endpoints"
     assert captured["params"] == {"edge": "true", "status": "true"}
+
+
+def test_create_backup_posts_to_backup_endpoint(monkeypatch):
+    client = PortainerClient(base_url="https://portainer.example", api_key="token")
+
+    captured: dict[str, object] = {}
+
+    class DummyResponse:
+        headers = {"Content-Disposition": "attachment; filename*=UTF-8''portainer.tar.gz"}
+        content = b"backup-data"
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    def fake_post(url, headers, json, timeout, verify):  # type: ignore[override]
+        captured.update(
+            {
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+                "verify": verify,
+            }
+        )
+        return DummyResponse()
+
+    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
+
+    payload, filename = client.create_backup(password="secret")
+
+    assert captured["url"] == "https://portainer.example/api/backup"
+    assert captured["json"] == {"password": "secret"}
+    assert payload == b"backup-data"
+    assert filename == "portainer.tar.gz"
+
+
+def test_create_backup_raises_on_request_errors(monkeypatch):
+    client = PortainerClient(base_url="https://portainer.example", api_key="token")
+
+    def fake_post(*args, **kwargs):  # type: ignore[override]
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
+
+    with pytest.raises(PortainerAPIError):
+        client.create_backup()


### PR DESCRIPTION
## Summary
- add a Portainer client helper for triggering `/backup` and parsing the returned archive name
- persist backups on disk with a new backup service and surface it from the Settings page
- expose a password-protected backup workflow in the UI and list the last saved archive for download

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e3927598548333ae65a49535035bd8