### PR TITLE
Fix backup directory path to be writable

### DIFF
--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -24,7 +24,8 @@ def backup_directory() -> Path:
     override = os.getenv(_BACKUP_DIR_ENV_VAR)
     if override:
         return Path(override).expanduser()
-    return Path(__file__).resolve().parent.parent / ".streamlit" / "backups"
+    project_root = Path(__file__).resolve().parents[2]
+    return project_root / ".streamlit" / "backups"
 
 
 def _ensure_backup_directory() -> Path:

--- a/tests/test_backup_service.py
+++ b/tests/test_backup_service.py
@@ -77,3 +77,12 @@ def test_create_environment_backup_generates_unique_names(tmp_path, monkeypatch)
     assert first != second
     assert first.exists() and second.exists()
     assert second.name != first.name
+
+
+def test_backup_directory_defaults_to_project_streamlit_dir(monkeypatch):
+    monkeypatch.delenv("PORTAINER_BACKUP_DIR", raising=False)
+
+    expected_root = Path(__file__).resolve().parents[1]
+    expected = expected_root / ".streamlit" / "backups"
+
+    assert backup_service.backup_directory() == expected

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -35,9 +35,6 @@ def test_list_edge_endpoints_requests_status(monkeypatch):
 
 
 def test_create_backup_posts_to_backup_endpoint(monkeypatch):
-def test_get_stack_image_status(monkeypatch):
-    """Stack image status requests should hit the expected endpoint."""
-
     client = PortainerClient(base_url="https://portainer.example", api_key="token")
 
     captured: dict[str, object] = {}
@@ -72,16 +69,13 @@ def test_get_stack_image_status(monkeypatch):
     assert filename == "portainer.tar.gz"
 
 
-def test_create_backup_raises_on_request_errors(monkeypatch):
+def test_get_stack_image_status(monkeypatch):
+    """Stack image status requests should hit the expected endpoint."""
+
     client = PortainerClient(base_url="https://portainer.example", api_key="token")
 
-    def fake_post(*args, **kwargs):  # type: ignore[override]
-        raise requests.RequestException("boom")
+    captured: dict[str, object] = {}
 
-    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
-
-    with pytest.raises(PortainerAPIError):
-        client.create_backup()
     def fake_request(path: str, *, params=None):  # type: ignore[override]
         captured["path"] = path
         captured["params"] = params
@@ -94,3 +88,15 @@ def test_create_backup_raises_on_request_errors(monkeypatch):
     assert captured["path"] == "/stacks/42/images_status"
     assert captured["params"] is None
     assert payload == {"Status": "updated"}
+
+
+def test_create_backup_raises_on_request_errors(monkeypatch):
+    client = PortainerClient(base_url="https://portainer.example", api_key="token")
+
+    def fake_post(*args, **kwargs):  # type: ignore[override]
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
+
+    with pytest.raises(PortainerAPIError):
+        client.create_backup()


### PR DESCRIPTION
## Summary
- ensure Portainer backups default to the project-level `.streamlit/backups` directory so the runtime user can write the archive
- add a regression test covering the default backup directory resolution
- tidy the Portainer client tests to restore the missing coverage for stack image status and backup errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3ae0fe4a08333bd8564228efdb77d