### PR TITLE
Fix backup password widget reset and add default password support

### DIFF
--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -13,9 +13,14 @@ try:  # pragma: no cover - import shim for Streamlit runtime
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
     from portainer_client import PortainerClient  # type: ignore[no-redef]
 
-__all__ = ["backup_directory", "create_environment_backup"]
+__all__ = [
+    "backup_directory",
+    "create_environment_backup",
+    "default_backup_password",
+]
 
 _BACKUP_DIR_ENV_VAR = "PORTAINER_BACKUP_DIR"
+_BACKUP_PASSWORD_ENV_VAR = "PORTAINER_BACKUP_PASSWORD"
 
 
 def backup_directory() -> Path:
@@ -32,6 +37,16 @@ def _ensure_backup_directory() -> Path:
     directory = backup_directory()
     directory.mkdir(parents=True, exist_ok=True)
     return directory
+
+
+def default_backup_password() -> Optional[str]:
+    """Return the configured default password for Portainer backups."""
+
+    value = os.getenv(_BACKUP_PASSWORD_ENV_VAR)
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
 
 
 def _sanitise_component(value: str) -> str:

--- a/app/services/backup_scheduler.py
+++ b/app/services/backup_scheduler.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Mapping
 
-from .backup import backup_directory, create_environment_backup
+from .backup import (
+    backup_directory,
+    create_environment_backup,
+    default_backup_password,
+)
 
 __all__ = [
     "configured_interval_seconds",
@@ -178,9 +182,11 @@ def maybe_run_scheduled_backups(
         return []
 
     generated: List[Path] = []
+    password = default_backup_password()
     for environment in envs:
         try:
-            path = create_environment_backup(environment)
+            kwargs = {"password": password} if password else {}
+            path = create_environment_backup(environment, **kwargs)
         except Exception as exc:  # pragma: no cover - defensive guard
             env_name = str(environment.get("name", "environment"))
             LOGGER.warning(


### PR DESCRIPTION
## Summary
- prevent Streamlit session state errors by resetting the backup password field before rendering the widget
- add support for configuring a default backup password via the PORTAINER_BACKUP_PASSWORD environment variable
- ensure scheduled and manual backups reuse the configured password when no custom value is provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b6f06e4c833391b5bc8a8c73cbd7