### PR TITLE
Implement background refresh for Portainer cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ accent colour is overridden, so the interface remains readable in either mode.
 The dashboard now caches Portainer API responses to reduce latency for returning users. The first fetch after
 start-up populates the cache on disk (by default inside `.streamlit/cache`, which is persisted automatically when
 using the provided Docker volume). Subsequent logins reuse the cached data until either the configured TTL expires
-or the cache is invalidated. The cache is automatically cleared when operators switch the active Portainer
-environment, press the **Refresh data** button in the sidebar, or modify the saved environment configuration. You
+or the cache is invalidated. When cached data becomes stale the dashboard serves the previous snapshot immediately
+and refreshes it in the background, clearly indicating when the repull is in progress. The cache is automatically
+cleared when operators switch the active Portainer environment, press the **Refresh data** button in the sidebar,
+or modify the saved environment configuration. You
 can adjust or disable the behaviour through the new environment variables documented above.
 
 ### LLM assistant

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -17,6 +17,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
@@ -38,6 +39,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
@@ -75,19 +77,28 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    stack_data, container_data, warnings = fetch_portainer_data(configured_environments)
+    data_result = fetch_portainer_data(configured_environments)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()
 
-for warning in warnings:
+render_data_refresh_notice(data_result)
+
+for warning in data_result.warnings:
     st.warning(warning, icon="⚠️")
+
+stack_data = data_result.stack_data
+container_data = data_result.container_data
 
 if stack_data.empty and container_data.empty:
     st.info("No data was returned by the Portainer API for the configured account.")
     st.stop()
 
-filters = render_sidebar_filters(stack_data, container_data)
+filters = render_sidebar_filters(
+    stack_data,
+    container_data,
+    data_status=data_result,
+)
 
 stack_filtered = filters.stack_data
 containers_filtered = filters.container_data

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -24,6 +24,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
@@ -41,6 +42,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
@@ -81,21 +83,30 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    stack_data, container_data, warnings = fetch_portainer_data(
+    data_result = fetch_portainer_data(
         configured_environments, include_stopped=True
     )
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()
 
-for warning in warnings:
+render_data_refresh_notice(data_result)
+
+for warning in data_result.warnings:
     st.warning(warning, icon="⚠️")
+
+stack_data = data_result.stack_data
+container_data = data_result.container_data
 
 if stack_data.empty and container_data.empty:
     st.info("No data was returned by the Portainer API for the configured account.")
     st.stop()
 
-filters = render_sidebar_filters(stack_data, container_data)
+filters = render_sidebar_filters(
+    stack_data,
+    container_data,
+    data_status=data_result,
+)
 
 stack_filtered = filters.stack_data
 containers_filtered = filters.container_data

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -23,6 +23,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
@@ -40,6 +41,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
@@ -75,19 +77,28 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    stack_data, container_data, warnings = fetch_portainer_data(configured_environments)
+    data_result = fetch_portainer_data(configured_environments)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()
 
-for warning in warnings:
+render_data_refresh_notice(data_result)
+
+for warning in data_result.warnings:
     st.warning(warning, icon="⚠️")
+
+stack_data = data_result.stack_data
+container_data = data_result.container_data
 
 if stack_data.empty and container_data.empty:
     st.info("No data was returned by the Portainer API for the configured account.")
     st.stop()
 
-filters = render_sidebar_filters(stack_data, container_data)
+filters = render_sidebar_filters(
+    stack_data,
+    container_data,
+    data_status=data_result,
+)
 
 containers_filtered = filters.container_data
 

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -20,6 +20,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
@@ -43,6 +44,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        render_data_refresh_notice,
         render_sidebar_filters,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
@@ -110,17 +112,26 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    stack_data, container_data, warnings = fetch_portainer_data(
+    data_result = fetch_portainer_data(
         configured_environments, include_stopped=True
     )
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()
 
-for warning in warnings:
+render_data_refresh_notice(data_result)
+
+for warning in data_result.warnings:
     st.warning(warning, icon="⚠️")
 
-filters = render_sidebar_filters(stack_data, container_data)
+stack_data = data_result.stack_data
+container_data = data_result.container_data
+
+filters = render_sidebar_filters(
+    stack_data,
+    container_data,
+    data_status=data_result,
+)
 stack_filtered = filters.stack_data
 containers_filtered = filters.container_data
 


### PR DESCRIPTION
## Summary
- retain Portainer cache metadata so stale snapshots remain available with a timestamp
- refresh expired cache entries in the background and surface refresh status through the UI
- update the dashboard pages and documentation to describe the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3f6b81cec8333b158f7bc8bf8a8eb