### PR TITLE
Fix undefined warnings reference in LLM assistant page

### DIFF
--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -121,7 +121,8 @@ except PortainerAPIError as exc:
 
 render_data_refresh_notice(data_result)
 
-for warning in data_result.warnings:
+warnings = tuple(data_result.warnings)
+for warning in warnings:
     st.warning(warning, icon="⚠️")
 
 stack_data = data_result.stack_data


### PR DESCRIPTION
## Summary
- cache the Portainer warnings list before reusing it on the LLM assistant page
- prevent NameError by referencing the stored warnings when building the context payload

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3fc8b2afc83339f26013b147b1c68