### PR TITLE
Add support for system-wide LLM bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The application is configured via environment variables:
 - `PORTAINER_CACHE_TTL_SECONDS` – Optional. Number of seconds before cached Portainer API responses are refreshed. Defaults to 900 seconds (15 minutes). Set to `0` or a negative value to keep cached data until it is manually invalidated.
 - `PORTAINER_CACHE_DIR` – Optional. Directory used to persist cached Portainer data. Defaults to `.streamlit/cache` inside the application directory.
 - `PORTAINER_BACKUP_INTERVAL` – Optional. Interval used for automatic Portainer backups (for example `24h` or `30m`). Set to `0`, `off`, or leave unset to disable recurring backups. The dashboard persists the next scheduled run on disk so restarts continue the cadence without creating duplicate backups.
+- `LLM_BEARER_TOKEN` – Optional. When set, the LLM assistant page pre-populates the bearer token field so every authenticated user can reuse the shared credentials.
 
 Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
 operators can fix the configuration before exposing the dashboard.
@@ -58,7 +59,9 @@ can adjust or disable the behaviour through the new environment variables docume
 
 The **LLM assistant** page lets you connect an OpenWebUI/Ollama deployment to the dashboard. Provide the chat
 completion endpoint (for example `https://llm.example.com/v1/chat/completions`), your API token and
-model name (such as `gpt-oss`). The token field accepts either a traditional bearer token or a `username:password`
+model name (such as `gpt-oss`). When the `LLM_BEARER_TOKEN` environment variable is present, the bearer-token
+field is pre-filled automatically so operators can start querying immediately. The token field accepts either a
+traditional bearer token or a `username:password`
 pair, which is automatically sent using HTTP Basic authentication when detected. The page summarises the containers and stacks returned by Portainer—including any
 warnings—and sends that context along with your natural language question. This makes it possible to ask questions
 like “are there any containers that have issues and why?” directly from the dashboard. Responses are displayed in

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Iterable
 from typing import Mapping
 
@@ -141,6 +142,7 @@ if stack_filtered.empty and containers_filtered.empty:
 
 
 DEFAULT_ENDPOINT = "https://llm.example.com/v1/chat/completions"
+SYSTEM_BEARER_TOKEN = os.getenv("LLM_BEARER_TOKEN")
 
 with st.form("llm_query_form", enter_to_submit=False, clear_on_submit=False):
     api_endpoint = st.text_input(
@@ -169,13 +171,19 @@ with st.form("llm_query_form", enter_to_submit=False, clear_on_submit=False):
             "username/password credentials use HTTP Basic auth."
         ),
     )
-    bearer_token = st.session_state.get("llm_bearer_token", "")
+    if "llm_bearer_token" in st.session_state:
+        bearer_token_default = str(st.session_state.get("llm_bearer_token", ""))
+    elif SYSTEM_BEARER_TOKEN is not None:
+        bearer_token_default = SYSTEM_BEARER_TOKEN
+    else:
+        bearer_token_default = ""
+    bearer_token = bearer_token_default
     basic_username = st.session_state.get("llm_basic_username", "")
     basic_password = st.session_state.get("llm_basic_password", "")
     if auth_mode == "Bearer token":
         bearer_token = st.text_input(
             "Bearer token",
-            value=bearer_token,
+            value=bearer_token_default,
             type="password",
             help="Provide the access token issued by your Ollama proxy or OpenWebUI deployment.",
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME:?Set dashboard username}
       DASHBOARD_KEY: ${DASHBOARD_KEY:?Set dashboard key}
+      LLM_BEARER_TOKEN: ${LLM_BEARER_TOKEN:-}
     volumes:
       - streamlit_portainer_envs:/app/.streamlit
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- allow the LLM assistant to reuse a shared bearer token exposed via the `LLM_BEARER_TOKEN` environment variable
- document the new environment variable and plumb it through the Docker Compose configuration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3fee22ae48333a592222b462385b5