### PR TITLE
Add central logging configuration with configurable levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The application is configured via environment variables:
 - `DASHBOARD_USERNAME` – Username required to sign in to the dashboard UI.
 - `DASHBOARD_KEY` – Access key (password) required to sign in to the dashboard UI.
 - `DASHBOARD_SESSION_TIMEOUT_MINUTES` – Optional. Expire authenticated sessions after the specified number of minutes of inactivity. Omit or set to a non-positive value to disable the timeout.
+- `DASHBOARD_LOG_LEVEL` – Optional. Overrides the log verbosity for the dashboard. Accepts standard Python levels (e.g. `INFO`, `DEBUG`, `ERROR`) plus `TRACE`/`VERBOSE`. Defaults to `INFO` when unset or invalid.
 - `PORTAINER_CACHE_ENABLED` – Optional. Defaults to `true`. Set to `false` to disable persistent caching of Portainer API responses between sessions.
 - `PORTAINER_CACHE_TTL_SECONDS` – Optional. Number of seconds before cached Portainer API responses are refreshed. Defaults to 900 seconds (15 minutes). Set to `0` or a negative value to keep cached data until it is manually invalidated.
 - `PORTAINER_CACHE_DIR` – Optional. Directory used to persist cached Portainer data. Defaults to `.streamlit/cache` inside the application directory.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,9 @@
+"""Application package for the Streamlit Portainer dashboard."""
+from __future__ import annotations
+
+from .logging_setup import configure_logging
+
+configure_logging()
+
+__all__ = ["configure_logging"]
+

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,0 +1,99 @@
+"""Central logging configuration for the Streamlit Portainer dashboard."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+TRACE_LEVEL = 5
+logging.addLevelName(TRACE_LEVEL, "TRACE")
+
+
+def _trace(self: logging.Logger, message: str, *args: Any, **kwargs: Any) -> None:
+    if self.isEnabledFor(TRACE_LEVEL):
+        self._log(TRACE_LEVEL, message, args, **kwargs)  # type: ignore[call-arg]
+
+
+logging.Logger.trace = _trace  # type: ignore[attr-defined]
+
+_LOG_LEVEL_ALIASES: dict[str, int] = {
+    "trace": TRACE_LEVEL,
+    "verbose": logging.DEBUG,
+    "debug": logging.DEBUG,
+    "information": logging.INFO,
+    "info": logging.INFO,
+    "warn": logging.WARNING,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_INITIALISED = False
+
+
+class _MaxLevelFilter(logging.Filter):
+    """Filter that allows log records up to ``max_level`` (inclusive)."""
+
+    def __init__(self, max_level: int) -> None:
+        super().__init__(name="")
+        self.max_level = max_level
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - inherited docstring
+        return record.levelno <= self.max_level
+
+
+def _resolve_level(level: str | int) -> int:
+    if isinstance(level, int):
+        return level
+    cleaned = level.strip().lower()
+    if not cleaned:
+        return logging.INFO
+    if cleaned.isdigit():
+        return int(cleaned)
+    return _LOG_LEVEL_ALIASES.get(cleaned, logging.INFO)
+
+
+def _build_handler(stream: Any, *, level: int) -> logging.Handler:
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(level)
+    handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    return handler
+
+
+def configure_logging(*, level: str | int | None = None, force: bool = False) -> None:
+    """Configure structured console logging for the dashboard.
+
+    The configuration prefers stdout for diagnostic output (TRACE, DEBUG, INFO,
+    WARNING) while routing ERROR+ to stderr. The minimum log level can be
+    overridden with ``DASHBOARD_LOG_LEVEL`` or by passing ``level``.
+    """
+
+    global _INITIALISED
+    if _INITIALISED and not force:
+        return
+
+    requested_level: str | int = level if level is not None else os.getenv("DASHBOARD_LOG_LEVEL", "INFO")
+    numeric_level = max(TRACE_LEVEL, _resolve_level(requested_level))
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    root_logger.setLevel(numeric_level)
+
+    stdout_handler = _build_handler(sys.stdout, level=TRACE_LEVEL)
+    stdout_handler.addFilter(_MaxLevelFilter(logging.WARNING))
+
+    stderr_handler = _build_handler(sys.stderr, level=logging.ERROR)
+
+    root_logger.addHandler(stdout_handler)
+    root_logger.addHandler(stderr_handler)
+
+    _INITIALISED = True
+

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,36 @@
+"""Tests for the logging configuration helpers."""
+from __future__ import annotations
+
+import logging
+
+from app import logging_setup
+
+
+def test_configure_logging_routes_levels(capfd) -> None:
+    logging_setup.configure_logging(level="trace", force=True)
+    logger = logging.getLogger("tests.logging")
+
+    logger.trace("trace message")  # type: ignore[attr-defined]
+    logger.debug("debug message")
+    logger.info("info message")
+    logger.warning("warning message")
+    logger.error("error message")
+
+    captured = capfd.readouterr()
+    stdout = captured.out
+    stderr = captured.err
+
+    assert "trace message" in stdout
+    assert "debug message" in stdout
+    assert "info message" in stdout
+    assert "warning message" in stdout
+    assert "error message" in stderr
+    assert "error message" not in stdout
+
+
+def test_configure_logging_level_aliases(monkeypatch) -> None:
+    monkeypatch.setenv("DASHBOARD_LOG_LEVEL", "verbose")
+    logging_setup.configure_logging(force=True)
+
+    assert logging.getLogger().level == logging.DEBUG
+


### PR DESCRIPTION
## Summary
- add a reusable logging setup that introduces TRACE support and streams errors to stderr
- initialise the logging configuration when the app package loads and document the DASHBOARD_LOG_LEVEL variable
- cover the logging behaviour with tests for routing and level aliases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e40185b7048333862ac410d61c4aa6