### PR TITLE
Add active session metric to home dashboard

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -10,6 +10,7 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.auth import (  # type: ignore[import-not-found]
         render_logout_button,
         require_authentication,
+        get_active_session_count,
     )
     from app.dashboard_state import (  # type: ignore[import-not-found]
         apply_selected_environment,
@@ -20,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from auth import (  # type: ignore[no-redef]
         render_logout_button,
         require_authentication,
+        get_active_session_count,
     )
     from dashboard_state import (  # type: ignore[no-redef]
         apply_selected_environment,
@@ -113,6 +115,7 @@ secured_environment_count = sum(
     1 for env in saved_environments if bool(env.get("verify_ssl", True))
 )
 api_keys_available = sum(1 for env in saved_environments if env.get("api_key"))
+active_sessions = get_active_session_count()
 
 hero_col1, hero_col2 = st.columns([3, 2], gap="large")
 with hero_col1:
@@ -139,12 +142,21 @@ with hero_col2:
         """,
         unsafe_allow_html=True,
     )
-    metric_cols = st.columns(2, gap="medium")
-    metric_cols[0].metric("Environments", len(saved_environments), help="Configured Portainer environments")
+    metric_cols = st.columns(3, gap="medium")
+    metric_cols[0].metric(
+        "Environments",
+        len(saved_environments),
+        help="Configured Portainer environments",
+    )
     metric_cols[1].metric(
         "Secured connections",
         secured_environment_count,
         help="Environments with SSL verification enabled",
+    )
+    metric_cols[2].metric(
+        "Active sessions",
+        active_sessions,
+        help="Authenticated users currently connected to the dashboard",
     )
     st.metric(
         "API keys stored",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import auth
+
+
+def _setup_session_store(monkeypatch):
+    store: dict[str, auth._PersistentSession] = {}
+
+    def _get_store() -> dict[str, auth._PersistentSession]:
+        return store
+
+    monkeypatch.setattr(auth, "_get_persistent_sessions", _get_store)
+    return store
+
+
+def test_get_active_session_count_filters_expired_sessions(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    store["active"] = auth._PersistentSession(
+        username="alice",
+        authenticated_at=now - timedelta(minutes=10),
+        last_active=now - timedelta(minutes=1),
+        session_timeout=timedelta(minutes=30),
+    )
+    store["expired"] = auth._PersistentSession(
+        username="bob",
+        authenticated_at=now - timedelta(hours=2),
+        last_active=now - timedelta(hours=2),
+        session_timeout=timedelta(minutes=30),
+    )
+
+    assert auth.get_active_session_count(now=now) == 1
+    assert "expired" not in store
+
+
+def test_get_active_session_count_supports_sessions_without_timeout(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    store["persistent"] = auth._PersistentSession(
+        username="carol",
+        authenticated_at=now - timedelta(days=1),
+        last_active=now - timedelta(hours=1),
+        session_timeout=None,
+    )
+
+    assert auth.get_active_session_count(now=now) == 1


### PR DESCRIPTION
## Summary
- add an authentication helper to count active persistent sessions
- surface the active session total on the Home page quick insight metrics
- cover the new helper with unit tests for expired and persistent sessions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4019899e88333b0c8d49fb48a0357