### PR TITLE
Lock LLM assistant configuration when managed via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The application is configured via environment variables:
 - `PORTAINER_CACHE_TTL_SECONDS` – Optional. Number of seconds before cached Portainer API responses are refreshed. Defaults to 900 seconds (15 minutes). Set to `0` or a negative value to keep cached data until it is manually invalidated.
 - `PORTAINER_CACHE_DIR` – Optional. Directory used to persist cached Portainer data. Defaults to `.streamlit/cache` inside the application directory.
 - `PORTAINER_BACKUP_INTERVAL` – Optional. Interval used for automatic Portainer backups (for example `24h` or `30m`). Set to `0`, `off`, or leave unset to disable recurring backups. The dashboard persists the next scheduled run on disk so restarts continue the cadence without creating duplicate backups.
-- `LLM_BEARER_TOKEN` – Optional. When set, the LLM assistant page pre-populates the bearer token field so every authenticated user can reuse the shared credentials.
+- `LLM_API_ENDPOINT` – Optional. When set, the LLM assistant page defaults to this chat completion endpoint.
+- `LLM_BEARER_TOKEN` – Optional. When set, the LLM assistant page pre-populates the bearer token field so every authenticated user can reuse the shared credentials. When both `LLM_API_ENDPOINT` and `LLM_BEARER_TOKEN` are provided the endpoint and credential inputs become read-only, signalling that the deployment manages the LLM configuration.
 
 Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
 operators can fix the configuration before exposing the dashboard.
@@ -60,7 +61,9 @@ can adjust or disable the behaviour through the new environment variables docume
 The **LLM assistant** page lets you connect an OpenWebUI/Ollama deployment to the dashboard. Provide the chat
 completion endpoint (for example `https://llm.example.com/v1/chat/completions`), your API token and
 model name (such as `gpt-oss`). When the `LLM_BEARER_TOKEN` environment variable is present, the bearer-token
-field is pre-filled automatically so operators can start querying immediately. The token field accepts either a
+field is pre-filled automatically so operators can start querying immediately. Setting both `LLM_API_ENDPOINT`
+and `LLM_BEARER_TOKEN` locks the connection details, making it clear which managed LLM instance the dashboard uses.
+The token field accepts either a
 traditional bearer token or a `username:password`
 pair, which is automatically sent using HTTP Basic authentication when detected. The page summarises the containers and stacks returned by Portainer—including any
 warnings—and sends that context along with your natural language question. This makes it possible to ask questions


### PR DESCRIPTION
## Summary
- add support for an `LLM_API_ENDPOINT` environment variable and lock LLM assistant credentials when both endpoint and token are provided
- render a deployment-managed notice in the LLM assistant and document the new behaviour in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e402fb37f88333a7e37cd4943be358