### PR TITLE
Fix session token persistence after navigating between pages

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -236,6 +236,7 @@ def _update_persistent_session_activity(
 
     session.last_active = now
     session.session_timeout = session_timeout
+    _ensure_session_query_param(token)
     _set_session_cookie(token, now=now, session_timeout=session_timeout)
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -54,3 +54,32 @@ def test_get_active_session_count_supports_sessions_without_timeout(monkeypatch)
     )
 
     assert auth.get_active_session_count(now=now) == 1
+
+
+def test_update_session_activity_synchronises_query_param(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    token = "token-value"
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    store[token] = auth._PersistentSession(
+        username="alice",
+        authenticated_at=now - timedelta(minutes=5),
+        last_active=now - timedelta(minutes=1),
+        session_timeout=timedelta(minutes=30),
+    )
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state = {"_session_token": token}
+            self.query_params: dict[str, str] = {}
+            self.cookie_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def experimental_set_cookie(self, *args, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookie_calls.append((args, kwargs))
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+
+    auth._update_persistent_session_activity(now, timedelta(minutes=30))
+
+    assert dummy_streamlit.query_params["session_token"] == token


### PR DESCRIPTION
## Summary
- ensure active sessions re-sync the `session_token` query parameter during routine updates
- add a regression test to confirm query parameter synchronisation when refreshing after navigation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4068ff5cc833387f188db3cd2beba