### PR TITLE
Add Kibana log explorer for edge agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The application is configured via environment variables:
 - `PORTAINER_BACKUP_INTERVAL` – Optional. Interval used for automatic Portainer backups (for example `24h` or `30m`). Set to `0`, `off`, or leave unset to disable recurring backups. The dashboard persists the next scheduled run on disk so restarts continue the cadence without creating duplicate backups.
 - `LLM_API_ENDPOINT` – Optional. When set, the LLM assistant page defaults to this chat completion endpoint.
 - `LLM_BEARER_TOKEN` – Optional. When set, the LLM assistant page pre-populates the bearer token field so every authenticated user can reuse the shared credentials. When both `LLM_API_ENDPOINT` and `LLM_BEARER_TOKEN` are provided the endpoint and credential inputs become read-only, signalling that the deployment manages the LLM configuration.
+- `KIBANA_LOGS_ENDPOINT` – Optional. Full URL of the Kibana/Elasticsearch search endpoint (for example `https://elastic.example.com/_search`) used to retrieve container logs.
+- `KIBANA_API_KEY` – Optional. API key sent via the `Authorization: ApiKey <token>` header when querying Kibana. Required when `KIBANA_LOGS_ENDPOINT` is set.
+- `KIBANA_VERIFY_SSL` – Optional. Defaults to `true`. Set to `false` to skip TLS verification when connecting to Kibana with self-signed certificates.
+- `KIBANA_TIMEOUT_SECONDS` – Optional. Request timeout (in seconds) for Kibana log queries. Defaults to 30 seconds when unset or invalid.
 
 Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
 operators can fix the configuration before exposing the dashboard.
@@ -70,6 +74,14 @@ pair, which is automatically sent using HTTP Basic authentication when detected.
 warnings—and sends that context along with your natural language question. This makes it possible to ask questions
 like “are there any containers that have issues and why?” directly from the dashboard. Responses are displayed in
 the UI and you can download the exact context shared with the model for auditing.
+
+### Edge agent log explorer
+
+The **Edge agent logs** page surfaces container logs collected in Kibana/Elasticsearch. Configure the
+`KIBANA_LOGS_ENDPOINT` and `KIBANA_API_KEY` environment variables to enable the integration. The page reuses your
+current Portainer filters so you can drill into a specific subset of environments or endpoints before issuing a log
+query. Specify a time window (15 minutes to 24 hours), optional container name or message search term and download the
+results as CSV for further analysis.
 
 ## Usage
 

--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -1,0 +1,241 @@
+"""Edge agent log explorer backed by Kibana / Elasticsearch."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import streamlit as st
+
+try:  # pragma: no cover - import shim for Streamlit runtime
+    from app.auth import (  # type: ignore[import-not-found]
+        render_logout_button,
+        require_authentication,
+    )
+    from app.dashboard_state import (  # type: ignore[import-not-found]
+        ConfigurationError,
+        NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        fetch_portainer_data,
+        initialise_session_state,
+        load_configured_environment_settings,
+        render_data_refresh_notice,
+        render_sidebar_filters,
+    )
+    from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
+    from app.services.kibana_client import (  # type: ignore[import-not-found]
+        KibanaClientError,
+        load_kibana_client_from_env,
+    )
+    from app.ui_helpers import (  # type: ignore[import-not-found]
+        ExportableDataFrame,
+        render_page_header,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
+    from auth import (  # type: ignore[no-redef]
+        render_logout_button,
+        require_authentication,
+    )
+    from dashboard_state import (  # type: ignore[no-redef]
+        ConfigurationError,
+        NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        fetch_portainer_data,
+        initialise_session_state,
+        load_configured_environment_settings,
+        render_data_refresh_notice,
+        render_sidebar_filters,
+    )
+    from portainer_client import PortainerAPIError  # type: ignore[no-redef]
+    from services.kibana_client import (  # type: ignore[no-redef]
+        KibanaClientError,
+        load_kibana_client_from_env,
+    )
+    from ui_helpers import (  # type: ignore[no-redef]
+        ExportableDataFrame,
+        render_page_header,
+    )
+
+
+TIME_WINDOWS = {
+    "Last 15 minutes": timedelta(minutes=15),
+    "Last 1 hour": timedelta(hours=1),
+    "Last 6 hours": timedelta(hours=6),
+    "Last 24 hours": timedelta(hours=24),
+}
+
+
+def _build_agent_dataframe(container_data: pd.DataFrame) -> pd.DataFrame:
+    if container_data.empty:
+        return container_data
+    columns = ["endpoint_id", "endpoint_name"]
+    available_columns = [column for column in columns if column in container_data.columns]
+    if not available_columns:
+        return pd.DataFrame(columns=columns)
+    agents = (
+        container_data[available_columns]
+        .dropna()
+        .drop_duplicates()
+        .sort_values(by=available_columns)
+        .reset_index(drop=True)
+    )
+    if "endpoint_name" not in agents.columns:
+        agents["endpoint_name"] = agents[available_columns[0]].astype("string")
+    return agents
+
+
+require_authentication()
+render_logout_button()
+
+render_page_header(
+    "Edge agent logs",
+    icon="🪵",
+    description=(
+        "Query container logs stored in Elasticsearch / Kibana using the configured API key."
+    ),
+)
+
+initialise_session_state()
+apply_selected_environment()
+
+try:
+    configured_environments = load_configured_environment_settings()
+except ConfigurationError as exc:
+    st.error(str(exc))
+    st.stop()
+except NoEnvironmentsConfiguredError:
+    st.warning(
+        "No Portainer environments configured. Visit the Settings page to add one.",
+        icon="ℹ️",
+    )
+    st.stop()
+
+try:
+    data_result = fetch_portainer_data(configured_environments, include_stopped=True)
+except PortainerAPIError as exc:
+    st.error(f"Failed to load data from Portainer: {exc}")
+    st.stop()
+
+render_data_refresh_notice(data_result)
+
+for warning in data_result.warnings:
+    st.warning(warning, icon="⚠️")
+
+container_data = data_result.container_data
+
+agents_df = _build_agent_dataframe(container_data)
+if agents_df.empty:
+    st.info(
+        "No edge agents were discovered from the Portainer API response. Logs cannot be queried yet.",
+        icon="ℹ️",
+    )
+    st.stop()
+
+kibana_client = load_kibana_client_from_env()
+if kibana_client is None:
+    st.info(
+        "Configure the `KIBANA_LOGS_ENDPOINT` and `KIBANA_API_KEY` environment variables to enable log queries.",
+        icon="ℹ️",
+    )
+    st.stop()
+
+st.sidebar.header("Log filters")
+
+filters = render_sidebar_filters(
+    data_result.stack_data,
+    container_data,
+    data_status=data_result,
+)
+
+agents_in_scope = _build_agent_dataframe(filters.container_data)
+if agents_in_scope.empty:
+    st.info(
+        "The current filters hide all edge agents. Adjust the sidebar scope to continue.",
+        icon="ℹ️",
+    )
+    st.stop()
+
+default_agent = agents_in_scope["endpoint_name"].astype("string").iloc[0]
+
+with st.form("kibana_log_filters"):
+    agent_display = (
+        agents_in_scope["endpoint_name"].astype("string").sort_values().unique().tolist()
+    )
+    selected_agent = st.selectbox(
+        "Edge agent",
+        options=agent_display,
+        index=agent_display.index(default_agent) if default_agent in agent_display else 0,
+        help="Select the edge agent (host.hostname) to query logs for.",
+    )
+    hostname = st.text_input(
+        "host.hostname filter",
+        value=selected_agent,
+        help=(
+            "Exact `host.hostname` value used by the logs. Override this if the Kibana hostname differs from the Portainer name."
+        ),
+    ).strip()
+    container_filter = st.text_input(
+        "Container name filter",
+        value="",
+        help="Optional. When provided only logs from this exact container name are returned.",
+    ).strip() or None
+    search_term = st.text_input(
+        "Search within message",
+        value="",
+        help="Optional free-text search applied to the log message field.",
+    ).strip() or None
+    time_window_label = st.selectbox(
+        "Time range",
+        options=list(TIME_WINDOWS.keys()),
+        index=1,
+    )
+    max_results = st.slider(
+        "Maximum number of log entries",
+        min_value=10,
+        max_value=500,
+        value=200,
+        step=10,
+    )
+    submitted = st.form_submit_button("Query logs", type="primary")
+
+if not submitted:
+    st.stop()
+
+if not hostname:
+    st.warning("Provide a hostname to query logs for.", icon="⚠️")
+    st.stop()
+
+time_window = TIME_WINDOWS.get(time_window_label, timedelta(hours=1))
+now = datetime.now(timezone.utc)
+start_time = now - time_window
+
+try:
+    logs_df = kibana_client.fetch_logs(
+        hostname=hostname,
+        start_time=start_time,
+        end_time=now,
+        container_name=container_filter,
+        search_term=search_term,
+        size=max_results,
+    )
+except (ValueError, KibanaClientError) as exc:
+    st.error(f"Failed to query Kibana logs: {exc}")
+    st.stop()
+
+if logs_df.empty:
+    st.info("No logs matched the selected filters for the requested time range.", icon="ℹ️")
+    st.stop()
+
+logs_df = logs_df.sort_values("timestamp", ascending=False).reset_index(drop=True)
+
+st.dataframe(logs_df, use_container_width=True, hide_index=True)
+
+export = ExportableDataFrame(
+    label="Download results as CSV",
+    data=logs_df,
+    filename=f"edge-agent-logs-{hostname}-{now:%Y%m%d%H%M%S}.csv",
+)
+export.render_download_button()
+
+st.caption(
+    "Results ordered by the most recent log entry first."
+)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,4 +1,4 @@
 """Service layer helpers for the Streamlit dashboard."""
 
-__all__ = ["backup", "backup_scheduler", "llm_client"]
+__all__ = ["backup", "backup_scheduler", "kibana_client", "llm_client"]
 

--- a/app/services/kibana_client.py
+++ b/app/services/kibana_client.py
@@ -1,0 +1,252 @@
+"""Helpers for querying Kibana / Elasticsearch log streams."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import os
+from typing import Any, Dict, Iterable, List, Mapping
+
+import pandas as pd
+import requests
+
+__all__ = [
+    "KibanaClient",
+    "KibanaClientError",
+    "KibanaLogEntry",
+    "build_logs_query",
+    "load_kibana_client_from_env",
+]
+
+
+class KibanaClientError(RuntimeError):
+    """Raised when log retrieval from Kibana fails."""
+
+
+@dataclass(slots=True)
+class KibanaLogEntry:
+    """A normalised representation of a single log entry."""
+
+    timestamp: str
+    message: str
+    container_name: str | None = None
+    agent_hostname: str | None = None
+    log_level: str | None = None
+    raw: Mapping[str, Any] | None = None
+
+
+def _parse_bool(value: str | None, *, default: bool = True) -> bool:
+    if value is None:
+        return default
+    cleaned = value.strip().lower()
+    if not cleaned:
+        return default
+    return cleaned not in {"0", "false", "no", "off"}
+
+
+def build_logs_query(
+    *,
+    hostname: str,
+    start_time: datetime,
+    end_time: datetime,
+    container_name: str | None = None,
+    search_term: str | None = None,
+    size: int = 200,
+) -> Dict[str, Any]:
+    """Return the Elasticsearch DSL query used to fetch logs."""
+
+    must_clauses: List[Dict[str, Any]] = [
+        {"exists": {"field": "container.name"}},
+        {"term": {"data_stream.dataset": "docker-container_logs"}},
+        {"term": {"host.hostname.keyword": hostname}},
+    ]
+
+    if container_name:
+        must_clauses.append({"term": {"container.name.keyword": container_name}})
+
+    if search_term:
+        must_clauses.append({"match_phrase": {"message": search_term}})
+
+    query: Dict[str, Any] = {
+        "size": max(1, min(size, 1000)),
+        "sort": [{"@timestamp": {"order": "desc"}}],
+        "query": {
+            "bool": {
+                "must": must_clauses,
+                "filter": [
+                    {
+                        "range": {
+                            "@timestamp": {
+                                "gte": start_time.isoformat(),
+                                "lte": end_time.isoformat(),
+                            }
+                        }
+                    }
+                ],
+            }
+        },
+    }
+
+    return query
+
+
+class KibanaClient:
+    """Lightweight client for querying Kibana / Elasticsearch APIs."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        api_key: str,
+        verify_ssl: bool = True,
+        timeout: int = 30,
+    ) -> None:
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        if not api_key:
+            raise ValueError("api_key is required")
+        self._endpoint = endpoint.rstrip("/")
+        self._api_key = api_key
+        self._verify_ssl = verify_ssl
+        self._timeout = timeout
+
+    def _request(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        headers = {
+            "Authorization": f"ApiKey {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            response = requests.post(
+                self._endpoint,
+                headers=headers,
+                json=payload,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise KibanaClientError(f"Failed to query Kibana logs: {exc}") from exc
+        try:
+            return response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - invalid server response
+            raise KibanaClientError("Kibana response was not valid JSON") from exc
+
+    def fetch_logs(
+        self,
+        *,
+        hostname: str,
+        start_time: datetime,
+        end_time: datetime,
+        container_name: str | None = None,
+        search_term: str | None = None,
+        size: int = 200,
+    ) -> pd.DataFrame:
+        """Fetch log entries for an edge agent within the provided time window."""
+
+        if not hostname.strip():
+            raise ValueError("hostname is required")
+
+        query = build_logs_query(
+            hostname=hostname.strip(),
+            start_time=start_time,
+            end_time=end_time,
+            container_name=container_name.strip() if container_name else None,
+            search_term=search_term.strip() if search_term else None,
+            size=size,
+        )
+        payload = self._request(query)
+        hits = payload.get("hits", {})
+        records_raw: Iterable[Mapping[str, Any]] = hits.get("hits", [])  # type: ignore[assignment]
+
+        entries: List[KibanaLogEntry] = []
+        for record in records_raw:
+            source = record.get("_source", {})
+            if not isinstance(source, Mapping):
+                continue
+            timestamp = str(source.get("@timestamp", ""))
+            message = str(source.get("message", ""))
+            container_name_value: str | None = None
+            container_source = source.get("container")
+            if isinstance(container_source, Mapping):
+                container_name_value = (
+                    container_source.get("name")
+                    or container_source.get("id")
+                    or container_source.get("image")
+                )
+                if container_name_value:
+                    container_name_value = str(container_name_value)
+            elif "container.name" in source:
+                container_name_value = str(source.get("container.name"))
+
+            host_value: str | None = None
+            host_source = source.get("host")
+            if isinstance(host_source, Mapping):
+                host_value = host_source.get("hostname") or host_source.get("name")
+                if host_value:
+                    host_value = str(host_value)
+            elif "host.hostname" in source:
+                host_value = str(source.get("host.hostname"))
+
+            log_level_value: str | None = None
+            log_source = source.get("log")
+            if isinstance(log_source, Mapping):
+                log_level_value = log_source.get("level")
+                if log_level_value:
+                    log_level_value = str(log_level_value)
+            elif "log.level" in source:
+                log_level_value = str(source.get("log.level"))
+
+            entries.append(
+                KibanaLogEntry(
+                    timestamp=timestamp,
+                    message=message,
+                    container_name=container_name_value,
+                    agent_hostname=host_value,
+                    log_level=log_level_value,
+                    raw=source,
+                )
+            )
+
+        if not entries:
+            return pd.DataFrame(
+                columns=["timestamp", "agent_hostname", "container_name", "log_level", "message"]
+            )
+
+        return pd.DataFrame.from_records(
+            (
+                {
+                    "timestamp": entry.timestamp,
+                    "agent_hostname": entry.agent_hostname,
+                    "container_name": entry.container_name,
+                    "log_level": entry.log_level,
+                    "message": entry.message,
+                }
+                for entry in entries
+            )
+        )
+
+
+def load_kibana_client_from_env() -> KibanaClient | None:
+    """Create a :class:`KibanaClient` from environment variables when available."""
+
+    endpoint = os.getenv("KIBANA_LOGS_ENDPOINT", "").strip()
+    api_key = os.getenv("KIBANA_API_KEY", "").strip()
+    if not endpoint or not api_key:
+        return None
+
+    verify_ssl = _parse_bool(os.getenv("KIBANA_VERIFY_SSL"), default=True)
+    timeout_raw = os.getenv("KIBANA_TIMEOUT_SECONDS", "").strip()
+    timeout = 30
+    if timeout_raw:
+        try:
+            timeout = max(1, int(float(timeout_raw)))
+        except ValueError:
+            timeout = 30
+
+    return KibanaClient(
+        endpoint=endpoint,
+        api_key=api_key,
+        verify_ssl=verify_ssl,
+        timeout=timeout,
+    )

--- a/tests/test_kibana_client.py
+++ b/tests/test_kibana_client.py
@@ -1,0 +1,117 @@
+"""Tests for the Kibana / Elasticsearch log client."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pandas as pd
+import pytest
+
+from app.services.kibana_client import (
+    KibanaClient,
+    build_logs_query,
+    load_kibana_client_from_env,
+)
+
+
+def test_build_logs_query_includes_expected_filters():
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2024, 1, 1, 1, tzinfo=timezone.utc)
+
+    query = build_logs_query(
+        hostname="edge-agent-1",
+        start_time=now,
+        end_time=later,
+        container_name="web",
+        search_term="error",
+        size=123,
+    )
+
+    assert query["size"] == 123
+    must = query["query"]["bool"]["must"]
+    assert {"exists": {"field": "container.name"}} in must
+    assert {"term": {"data_stream.dataset": "docker-container_logs"}} in must
+    assert {"term": {"host.hostname.keyword": "edge-agent-1"}} in must
+    assert {"term": {"container.name.keyword": "web"}} in must
+    assert {"match_phrase": {"message": "error"}} in must
+
+    time_filter = query["query"]["bool"]["filter"][0]["range"]["@timestamp"]
+    assert time_filter["gte"].startswith("2024-01-01T00:00:00")
+    assert time_filter["lte"].startswith("2024-01-01T01:00:00")
+
+
+def test_fetch_logs_returns_dataframe(monkeypatch):
+    captured_payload: Dict[str, Any] = {}
+
+    def fake_post(url, headers, json, timeout, verify):  # type: ignore[override]
+        captured_payload.update(
+            {
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+                "verify": verify,
+            }
+        )
+
+        class DummyResponse:
+            status_code = 200
+
+            @staticmethod
+            def raise_for_status() -> None:
+                return None
+
+            @staticmethod
+            def json() -> Dict[str, Any]:
+                return {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "@timestamp": "2024-01-01T01:23:45.000Z",
+                                    "message": "container log line",
+                                    "container": {"name": "web"},
+                                    "host": {"hostname": "edge-agent-1"},
+                                    "log": {"level": "info"},
+                                }
+                            }
+                        ]
+                    }
+                }
+
+        return DummyResponse()
+
+    monkeypatch.setattr("app.services.kibana_client.requests.post", fake_post)
+
+    client = KibanaClient(endpoint="https://elastic.example.com/_search", api_key="secret")
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2024, 1, 1, 1, tzinfo=timezone.utc)
+    result = client.fetch_logs(hostname="edge-agent-1", start_time=now, end_time=later)
+
+    assert captured_payload["url"] == "https://elastic.example.com/_search"
+    assert captured_payload["headers"]["Authorization"] == "ApiKey secret"
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+    assert list(result.columns) == [
+        "timestamp",
+        "agent_hostname",
+        "container_name",
+        "log_level",
+        "message",
+    ]
+
+
+def test_load_kibana_client_from_env(monkeypatch):
+    monkeypatch.setenv("KIBANA_LOGS_ENDPOINT", "https://elastic.example.com/_search")
+    monkeypatch.setenv("KIBANA_API_KEY", "abc123")
+    monkeypatch.setenv("KIBANA_VERIFY_SSL", "false")
+    monkeypatch.setenv("KIBANA_TIMEOUT_SECONDS", "15")
+
+    client = load_kibana_client_from_env()
+    assert isinstance(client, KibanaClient)
+
+    # Ensure the helper returns ``None`` when configuration is incomplete.
+    monkeypatch.delenv("KIBANA_LOGS_ENDPOINT", raising=False)
+    monkeypatch.delenv("KIBANA_API_KEY", raising=False)
+    assert load_kibana_client_from_env() is None


### PR DESCRIPTION
## Summary
- add a Kibana/Elasticsearch service client that queries container logs with API key authentication
- introduce an Edge agent logs Streamlit page that reuses existing filters and surfaces Kibana results
- document the new environment variables and cover the client with unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4be8372ac8333a86e052a2730d8f3