### PR TITLE
Fix Streamlit Arrow conversion for humanised status columns

### DIFF
--- a/app/dashboard_state.py
+++ b/app/dashboard_state.py
@@ -747,8 +747,10 @@ def _humanise_stack_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         ("stack_type", stack_type_mapping),
     ):
         if column in humanised.columns:
-            humanised[column] = humanised[column].apply(
-                lambda value, mapping=mapping: _humanise_value(value, mapping)
+            humanised[column] = (
+                humanised[column]
+                .apply(lambda value, mapping=mapping: _humanise_value(value, mapping))
+                .astype("string")
             )
     return humanised
 


### PR DESCRIPTION
## Summary
- ensure the humanised Portainer status fields are stored with pandas' string dtype so Streamlit no longer attempts to coerce them into integers during Arrow conversion

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c61890308333a775edefbd60d471