### PR TITLE
Add loading spinner for Portainer data fetches

### DIFF
--- a/app/dashboard_state.py
+++ b/app/dashboard_state.py
@@ -76,6 +76,7 @@ __all__ = [
     "apply_selected_environment",
     "clear_cached_data",
     "fetch_portainer_data",
+    "load_portainer_data",
     "get_saved_environments",
     "get_selected_environment_name",
     "initialise_session_state",
@@ -734,6 +735,21 @@ def render_data_refresh_notice(result: PortainerDataResult) -> None:
         st.warning(message, icon="⚠️")
     elif timestamp_text:
         st.caption(f"Last synced with Portainer on {timestamp_text}.")
+
+
+def load_portainer_data(
+    environments: tuple[PortainerEnvironment, ...],
+    *,
+    include_stopped: bool = False,
+    progress_message: str | None = None,
+) -> PortainerDataResult:
+    """Fetch Portainer data while surfacing progress feedback to the user."""
+
+    message = progress_message or "🔄 Fetching the latest data from Portainer…"
+    with st.spinner(message):
+        return fetch_portainer_data(
+            environments, include_stopped=include_stopped
+        )
 
 
 def _humanise_value(value: object, mapping: dict[int, str]) -> object:

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -14,9 +14,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -36,9 +36,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -77,7 +77,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(configured_environments)
+    data_result = load_portainer_data(configured_environments)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -21,9 +21,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -39,9 +39,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -83,7 +83,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(
+    data_result = load_portainer_data(
         configured_environments, include_stopped=True
     )
 except PortainerAPIError as exc:

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -20,9 +20,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -38,9 +38,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -77,7 +77,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(configured_environments)
+    data_result = load_portainer_data(configured_environments)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -24,9 +24,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -45,9 +45,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -319,7 +319,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(configured_environments)
+    data_result = load_portainer_data(configured_environments)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -18,9 +18,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -42,9 +42,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -113,7 +113,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(
+    data_result = load_portainer_data(
         configured_environments, include_stopped=True
     )
 except PortainerAPIError as exc:

--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -15,9 +15,9 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -39,9 +39,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         ConfigurationError,
         NoEnvironmentsConfiguredError,
         apply_selected_environment,
-        fetch_portainer_data,
         initialise_session_state,
         load_configured_environment_settings,
+        load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
     )
@@ -110,7 +110,7 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = fetch_portainer_data(configured_environments, include_stopped=True)
+    data_result = load_portainer_data(configured_environments, include_stopped=True)
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()


### PR DESCRIPTION
## Summary
- add a Streamlit spinner helper so Portainer data loads show in-progress feedback
- update all dashboards that fetch Portainer data to use the helper for clearer UX

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d16f4180833388f63a41834af99c