### PR TITLE
Add Python best practices reminder to agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agent Guidelines
 
+> Stick to Python best practices whenever possible. For additional guidance, refer to [this best practices guide](https://gist.github.com/ruimaranhao/4e18cbe3dad6f68040c32ed6709090a3).
+
 Welcome! This repository powers the Streamlit Portainer dashboard. Follow these tips when working inside this project:
 
 ## Project layout


### PR DESCRIPTION
## Summary
- add a reminder at the top of AGENTS.md to follow Python best practices, referencing the shared guide

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e4d2d87a4c8333bf00ae0d71cbad37