### PR TITLE
Improve LLM assistant context budgeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ field is pre-filled automatically so operators can start querying immediately. S
 and `LLM_BEARER_TOKEN` locks the connection details, making it clear which managed LLM instance the dashboard uses.
 The token field accepts either a
 traditional bearer token or a `username:password`
-pair, which is automatically sent using HTTP Basic authentication when detected. The page summarises the containers and stacks returned by Portainer—including any
-warnings—and sends that context along with your natural language question. This makes it possible to ask questions
-like “are there any containers that have issues and why?” directly from the dashboard. Responses are displayed in
-the UI and you can download the exact context shared with the model for auditing.
+pair, which is automatically sent using HTTP Basic authentication when detected. The page now builds an
+operational summary (container counts, unhealthy services, top CPU/memory consumers) before serialising the
+underlying Portainer tables. You can steer how much detail reaches the LLM by adjusting both the maximum number
+of container rows and a dedicated “Max context tokens” slider; the assistant automatically trims low-priority
+tables or reduces their size when the payload would exceed that budget. This keeps prompts efficient even when
+large environments are selected. The UI surfaces the exact context size, any trade-offs that were applied, and
+still allows you to download the data that was shared for auditing. With the context in place you can ask natural
+language questions—such as “are there any containers that have issues and why?”—and review the LLM response
+directly inside the dashboard.
 
 ### Edge agent log explorer
 

--- a/app/services/llm_context.py
+++ b/app/services/llm_context.py
@@ -1,0 +1,274 @@
+"""Helpers for shaping Portainer context payloads sent to the LLM."""
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+
+import pandas as pd
+
+__all__ = [
+    "build_context_summary",
+    "enforce_context_budget",
+    "estimate_token_count",
+    "serialise_records",
+]
+
+
+def serialise_records(df: pd.DataFrame) -> list[dict[str, object]]:
+    """Return JSON-serialisable records from *df*.
+
+    Streamlit dataframes often include rich objects (e.g. lists, timestamps) that the
+    JSON encoder cannot handle out-of-the-box. This helper coerces unsupported values
+    to strings while preserving scalars and ``None``/empty strings so that prompts
+    remain faithful to the original data.
+    """
+
+    if df.empty:
+        return []
+    serialised: list[dict[str, object]] = []
+    for record in df.to_dict(orient="records"):
+        cleaned: dict[str, object] = {}
+        for key, value in record.items():
+            if value in ("", None):
+                cleaned[key] = value
+            elif isinstance(value, (str, int, float, bool)):
+                cleaned[key] = value
+            else:
+                cleaned[key] = str(value)
+        serialised.append(cleaned)
+    return serialised
+
+
+def estimate_token_count(text: str) -> int:
+    """Return a rough token estimate for *text*.
+
+    We approximate the token count using the common heuristic of four characters per
+    token. This keeps the calculation fast while remaining conservative enough to
+    detect payloads that are likely to breach the model's context window.
+    """
+
+    if not text:
+        return 0
+    # ``math.ceil`` avoids underestimating payload size.
+    return math.ceil(len(text) / 4)
+
+
+def _to_numeric_percentage(series: pd.Series | None) -> pd.Series:
+    if series is None:
+        return pd.Series(dtype=float)
+    if pd.api.types.is_numeric_dtype(series):
+        return series.astype(float)
+    cleaned = series.astype(str).str.rstrip("%")
+    return pd.to_numeric(cleaned, errors="coerce")
+
+
+def build_context_summary(
+    containers: pd.DataFrame,
+    container_details: pd.DataFrame,
+    stacks: pd.DataFrame,
+    hosts: pd.DataFrame,
+    *,
+    top_n: int = 5,
+) -> dict[str, object]:
+    """Create a compact summary of key Portainer metrics.
+
+    The summary provides high-level counts and hotspot indicators so the LLM can
+    orient itself quickly even when detailed tables need to be trimmed.
+    """
+
+    summary: dict[str, object] = {}
+
+    if not containers.empty:
+        state_counts = (
+            containers.get("state", pd.Series(dtype=str))
+            .astype(str)
+            .str.lower()
+            .value_counts(dropna=True)
+            .to_dict()
+        )
+        status_series = containers.get("status", pd.Series(dtype=str)).astype(str)
+        unhealthy_count = int(
+            status_series.str.contains("unhealthy", case=False, na=False).sum()
+        )
+        summary["containers"] = {
+            "total": int(len(containers)),
+            "by_state": {key: int(value) for key, value in state_counts.items()},
+            "unhealthy": unhealthy_count,
+            "environments": sorted(
+                {
+                    str(value)
+                    for value in containers.get("environment_name", pd.Series(dtype=str))
+                    .dropna()
+                    .unique()
+                }
+            ),
+        }
+
+    if not stacks.empty:
+        summary["stacks"] = {
+            "total": int(len(stacks)),
+            "statuses": {
+                key: int(value)
+                for key, value in stacks.get("stack_status", pd.Series(dtype=str))
+                .astype(str)
+                .str.lower()
+                .value_counts(dropna=True)
+                .head(5)
+                .items()
+            },
+        }
+
+    if not hosts.empty:
+        summary["hosts"] = {
+            "total": int(len(hosts)),
+            "cpus": float(hosts.get("total_cpus", pd.Series(dtype=float)).fillna(0).sum()),
+            "memory_bytes": float(
+                hosts.get("total_memory", pd.Series(dtype=float)).fillna(0).sum()
+            ),
+        }
+
+    if not container_details.empty:
+        cpu_series = _to_numeric_percentage(container_details.get("cpu_percent"))
+        mem_series = _to_numeric_percentage(container_details.get("memory_percent"))
+        details_with_metrics = container_details.assign(
+            cpu_percent=cpu_series,
+            memory_percent=mem_series,
+        )
+
+        top_cpu = (
+            details_with_metrics.dropna(subset=["cpu_percent"])
+            .sort_values("cpu_percent", ascending=False)
+            .head(top_n)
+        )
+        if not top_cpu.empty:
+            summary["top_cpu"] = [
+                {
+                    "environment_name": row.get("environment_name", ""),
+                    "endpoint_name": row.get("endpoint_name", ""),
+                    "container_name": row.get("container_name", ""),
+                    "cpu_percent": round(float(row.get("cpu_percent", 0.0)), 2),
+                }
+                for row in top_cpu.to_dict(orient="records")
+            ]
+
+        top_memory = (
+            details_with_metrics.dropna(subset=["memory_percent"])
+            .sort_values("memory_percent", ascending=False)
+            .head(top_n)
+        )
+        if not top_memory.empty:
+            summary["top_memory"] = [
+                {
+                    "environment_name": row.get("environment_name", ""),
+                    "endpoint_name": row.get("endpoint_name", ""),
+                    "container_name": row.get("container_name", ""),
+                    "memory_percent": round(float(row.get("memory_percent", 0.0)), 2),
+                }
+                for row in top_memory.to_dict(orient="records")
+            ]
+
+    return summary
+
+
+def _estimate_payload_tokens(payload: Mapping[str, object]) -> int:
+    compact_json = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return estimate_token_count(compact_json)
+
+
+def enforce_context_budget(
+    payload: dict[str, object],
+    frames: dict[str, pd.DataFrame],
+    max_tokens: int,
+) -> tuple[dict[str, object], dict[str, pd.DataFrame], list[str], int]:
+    """Ensure *payload* stays within *max_tokens* by trimming lower-priority tables.
+
+    The function returns a ``(payload, frames, notices, token_count)`` tuple where
+    ``payload`` mirrors the final JSON sent to the LLM, ``frames`` exposes the
+    truncated DataFrames for UI rendering, and ``notices`` summarises any
+    adjustments applied.
+    """
+
+    payload_copy: dict[str, object] = dict(payload)
+    frames_copy: dict[str, pd.DataFrame] = {
+        key: df.copy() for key, df in frames.items()
+    }
+    if max_tokens <= 0:
+        token_count = _estimate_payload_tokens(payload_copy)
+        return payload_copy, frames_copy, [], token_count
+
+    notices: list[str] = []
+    token_count = _estimate_payload_tokens(payload_copy)
+
+    def _update_section(key: str, df: pd.DataFrame) -> None:
+        frames_copy[key] = df
+        payload_copy[key] = serialise_records(df)
+
+    while token_count > max_tokens:
+        adjusted = False
+
+        for key, minimum, message_template in (
+            (
+                "container_health",
+                5,
+                "Trimmed container health metrics to the first %s rows to respect the context budget.",
+            ),
+            (
+                "containers",
+                5,
+                "Trimmed container inventory to the first %s rows to respect the context budget.",
+            ),
+        ):
+            df = frames_copy.get(key)
+            if df is not None and len(df) > minimum:
+                new_length = max(minimum, len(df) // 2)
+                truncated = df.head(new_length)
+                _update_section(key, truncated)
+                token_count = _estimate_payload_tokens(payload_copy)
+                notices.append(message_template % new_length)
+                adjusted = True
+                break
+        if adjusted:
+            continue
+
+        for key, message in (
+            ("images", "Omitted image inventory to satisfy the context budget."),
+            ("volumes", "Omitted volume inventory to satisfy the context budget."),
+            ("hosts", "Omitted host capacity details to satisfy the context budget."),
+            ("stacks", "Omitted stack inventory to satisfy the context budget."),
+            ("endpoints", "Omitted endpoint metadata to satisfy the context budget."),
+            ("warnings", "Omitted Portainer warnings to satisfy the context budget."),
+        ):
+            if key in payload_copy:
+                payload_copy.pop(key, None)
+                frames_copy.pop(key, None)
+                token_count = _estimate_payload_tokens(payload_copy)
+                notices.append(message)
+                adjusted = True
+                break
+        if adjusted:
+            continue
+
+        df = frames_copy.get("containers")
+        if df is not None and len(df) > 5:
+            truncated = df.head(5)
+            _update_section("containers", truncated)
+            token_count = _estimate_payload_tokens(payload_copy)
+            notices.append(
+                "Reduced container inventory to the first 5 rows due to persistent context pressure."
+            )
+            continue
+
+        if "container_health" in payload_copy:
+            payload_copy.pop("container_health", None)
+            frames_copy.pop("container_health", None)
+            token_count = _estimate_payload_tokens(payload_copy)
+            notices.append(
+                "Removed detailed container health metrics due to persistent context pressure."
+            )
+            continue
+
+        # No further reductions possible – break to avoid an infinite loop.
+        break
+
+    return payload_copy, frames_copy, notices, token_count

--- a/tests/test_llm_context_manager.py
+++ b/tests/test_llm_context_manager.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from app.services.llm_context import (
+    build_context_summary,
+    enforce_context_budget,
+    estimate_token_count,
+    serialise_records,
+)
+
+
+def test_estimate_token_count_uses_conservative_rounding() -> None:
+    assert estimate_token_count("") == 0
+    assert estimate_token_count("abcd") == 1
+    assert estimate_token_count("abcde") == 2
+
+
+def test_build_context_summary_returns_hotspot_information() -> None:
+    containers = pd.DataFrame(
+        {
+            "state": ["running", "stopped", "running"],
+            "status": ["healthy", "unhealthy", "healthy"],
+            "environment_name": ["prod", "prod", "staging"],
+        }
+    )
+    container_details = pd.DataFrame(
+        {
+            "environment_name": ["prod", "prod", "staging"],
+            "endpoint_name": ["east", "west", "central"],
+            "container_name": ["api", "worker", "db"],
+            "cpu_percent": ["75%", "10%", "55%"],
+            "memory_percent": ["40%", "5%", "60%"],
+        }
+    )
+    stacks = pd.DataFrame({"stack_status": ["active", "deploying"]})
+    hosts = pd.DataFrame({"total_cpus": [4, 8], "total_memory": [8_000_000_000, 16_000_000_000]})
+
+    summary = build_context_summary(containers, container_details, stacks, hosts)
+
+    assert summary["containers"]["total"] == 3
+    assert summary["containers"]["unhealthy"] == 1
+    assert "running" in summary["containers"]["by_state"]
+    assert summary["stacks"]["total"] == 2
+    assert summary["hosts"]["cpus"] == 12.0
+    assert summary["hosts"]["memory_bytes"] == 24_000_000_000.0
+    assert summary["top_cpu"][0]["container_name"] == "api"
+    assert summary["top_memory"][0]["container_name"] == "db"
+
+
+def test_enforce_context_budget_trims_low_priority_sections() -> None:
+    containers = pd.DataFrame(
+        {"container_name": [f"c{i}" for i in range(20)], "state": ["running"] * 20}
+    )
+    container_health = pd.DataFrame(
+        {
+            "container_name": [f"c{i}" for i in range(20)],
+            "health_status": ["healthy"] * 20,
+        }
+    )
+    volumes = pd.DataFrame({"volume_name": [f"v{i}" for i in range(5)]})
+
+    frames = {
+        "containers": containers,
+        "container_health": container_health,
+        "volumes": volumes,
+    }
+
+    payload = {key: serialise_records(df) for key, df in frames.items()}
+    baseline_tokens = estimate_token_count(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    )
+
+    trimmed_payload, trimmed_frames, notices, final_tokens = enforce_context_budget(
+        payload, frames, max_tokens=1
+    )
+
+    assert final_tokens <= baseline_tokens
+    if "container_health" in trimmed_frames:
+        assert len(trimmed_frames["container_health"]) < len(container_health)
+    assert "volumes" not in trimmed_payload
+    assert notices  # user is informed about the adjustments
+    # Original frames remain untouched
+    assert len(containers) == 20
+    assert len(container_health) == 20


### PR DESCRIPTION
## Summary
- add reusable helpers for estimating prompt size, summarising Portainer telemetry, and pruning low-priority tables before sending LLM context
- expose a max context token slider, persist the new limits in session state, and surface context trimming notices plus a structured summary in the LLM assistant UI
- extend README guidance on the LLM assistant workflow and cover the new helpers with targeted unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4e86d3b148333a6ed7444e80f2365