### PR TITLE
Ensure LLM prompt uses compact context JSON

### DIFF
--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -484,6 +484,7 @@ if context_payload:
     context_token_count = estimate_token_count(context_json_compact)
 else:
     context_json_pretty = "{}"
+    context_json_compact = "{}"
     context_token_count = 0
 
 has_context_to_send = (
@@ -523,7 +524,9 @@ if submitted:
         st.error(auth_error)
     else:
         if has_context_to_send:
-            context_json = context_json_pretty
+            # Send the compact JSON payload to the model so the transmitted prompt
+            # matches the representation used for the token budget estimate.
+            context_json = context_json_compact
         else:
             st.info(
                 "There is no Portainer data available for the current filters. The question will be "


### PR DESCRIPTION
## Summary
- send the compact JSON payload to the LLM so the transmitted prompt matches the budgeting estimate
- default the compact JSON payload to an empty object when no context is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f1d29eac83338f242c8fa5cf0585