### PR TITLE
Allow custom LLM context budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ traditional bearer token or a `username:password`
 pair, which is automatically sent using HTTP Basic authentication when detected. The page now builds an
 operational summary (container counts, unhealthy services, top CPU/memory consumers) before serialising the
 underlying Portainer tables. You can steer how much detail reaches the LLM by adjusting both the maximum number
-of container rows and a dedicated “Max context tokens” slider; the assistant automatically trims low-priority
-tables or reduces their size when the payload would exceed that budget. This keeps prompts efficient even when
+of container rows and a dedicated “Max context tokens” control that accepts custom budgets for extended-context
+models; the assistant automatically trims low-priority tables or reduces their size when the payload would exceed
+that budget. This keeps prompts efficient even when
 large environments are selected. The UI surfaces the exact context size, any trade-offs that were applied, and
 still allows you to download the data that was shared for auditing. With the context in place you can ask natural
 language questions—such as “are there any containers that have issues and why?”—and review the LLM response

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -267,15 +267,18 @@ with st.form("llm_query_form", enter_to_submit=False, clear_on_submit=False):
         step=5,
         help="Limit the number of container rows shared with the LLM to keep prompts concise.",
     )
-    max_context_tokens = st.slider(
+    max_context_default = int(st.session_state.get("llm_max_context_tokens", 3000))
+    if max_context_default < 500:
+        max_context_default = 500
+    max_context_tokens = st.number_input(
         "Max context tokens",
         min_value=500,
-        max_value=8000,
-        value=int(st.session_state.get("llm_max_context_tokens", 3000)),
+        value=max_context_default,
         step=250,
         help=(
             "Upper bound for the approximate number of tokens allowed in the LLM context payload. "
-            "The assistant will trim or omit low-priority tables when this limit is exceeded."
+            "Enter larger values when using models with extended context windows; the assistant will "
+            "trim or omit low-priority tables when this limit is exceeded."
         ),
     )
     question = st.text_area(


### PR DESCRIPTION
## Summary
- replace the LLM assistant's max context slider with a number input so operators can enter larger token budgets for extended-context models
- document the new control in the README so the capability is visible to users

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fa353ed88333b232e3b41e0e3f54