### PR TITLE
Simplify edge agent hostname selection

### DIFF
--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -164,15 +164,8 @@ with st.form("kibana_log_filters"):
         "Edge agent",
         options=agent_display,
         index=agent_display.index(default_agent) if default_agent in agent_display else 0,
-        help="Select the edge agent (host.hostname) to query logs for.",
+        help="Select the edge agent to query logs for. This maps directly to the `host.hostname` value.",
     )
-    hostname = st.text_input(
-        "host.hostname filter",
-        value=selected_agent,
-        help=(
-            "Exact `host.hostname` value used by the logs. Override this if the Kibana hostname differs from the Portainer name."
-        ),
-    ).strip()
     container_filter = st.text_input(
         "Container name filter",
         value="",
@@ -199,6 +192,8 @@ with st.form("kibana_log_filters"):
 
 if not submitted:
     st.stop()
+
+hostname = selected_agent.strip()
 
 if not hostname:
     st.warning("Provide a hostname to query logs for.", icon="⚠️")


### PR DESCRIPTION
## Summary
- remove the redundant host.hostname text input on the Edge Agent Logs page
- use the selected edge agent value directly for Kibana queries and exports
- clarify helper text so the relationship between the agent selector and host.hostname is explicit

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fbc639748333b38662b1fcb64d87