### PR TITLE
feat: orchestrate llm prompts with planning and summaries

### DIFF
--- a/app/services/llm_workflow.py
+++ b/app/services/llm_workflow.py
@@ -1,0 +1,282 @@
+"""Utilities for managing LLM chat workflows inside the dashboard."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Iterator, Mapping
+
+__all__ = [
+    "ConversationExchange",
+    "ConversationHistory",
+    "QueryStrategy",
+]
+
+
+class QueryStrategy(str, Enum):
+    """Supported chat orchestration strategies."""
+
+    DIRECT = "direct"
+    SUMMARY = "summary"
+    STAGED = "staged"
+
+
+@dataclass(slots=True)
+class ConversationExchange:
+    """Represents a single question/answer pair with optional analysis plan."""
+
+    question: str
+    answer: str
+    plan: str | None = None
+
+
+def _truncate_to_budget(text: str, token_budget: int) -> str:
+    """Trim *text* so that it stays within the approximate *token_budget*."""
+
+    if token_budget <= 0 or not text:
+        return ""
+    approx_char_budget = token_budget * 4
+    if len(text) <= approx_char_budget:
+        return text
+    truncated = text[:approx_char_budget].rstrip()
+    if not truncated:
+        return ""
+    return truncated + "\n…"
+
+
+@dataclass
+class ConversationHistory:
+    """Stores recent exchanges and maintains a running summary of older turns."""
+
+    max_turns: int = 3
+    summary_token_budget: int = 600
+    exchanges: list[ConversationExchange] = field(default_factory=list)
+    summary: str = ""
+
+    def configure(self, *, max_turns: int, summary_token_budget: int) -> None:
+        """Update retention limits and enforce them immediately."""
+
+        if max_turns < 1:
+            max_turns = 1
+        self.max_turns = max_turns
+        if summary_token_budget < 0:
+            summary_token_budget = 0
+        self.summary_token_budget = summary_token_budget
+        self._enforce_limits()
+
+    def record_exchange(
+        self,
+        question: str,
+        answer: str,
+        *,
+        plan: str | None = None,
+    ) -> None:
+        """Add a new interaction and summarise if the window would overflow."""
+
+        self.exchanges.append(ConversationExchange(question=question, answer=answer, plan=plan))
+        self._enforce_limits()
+
+    def iter_recent_exchanges(self) -> Iterator[ConversationExchange]:
+        """Yield retained exchanges from oldest to newest."""
+
+        return iter(self.exchanges)
+
+    def build_answer_messages(
+        self,
+        *,
+        strategy: QueryStrategy,
+        system_prompt: str,
+        question: str,
+        context_json: str,
+        plan: str | None = None,
+    ) -> tuple[list[Mapping[str, str]], list[str]]:
+        """Construct chat messages for the answer phase."""
+
+        notices: list[str] = []
+        messages: list[Mapping[str, str]] = [{"role": "system", "content": system_prompt}]
+
+        if plan:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        "Use the following analysis plan when answering.\n"
+                        f"{plan.strip()}"
+                    ),
+                }
+            )
+
+        if strategy in (QueryStrategy.SUMMARY, QueryStrategy.STAGED):
+            if self.summary:
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": (
+                            "Conversation summary of earlier turns:\n"
+                            f"{self.summary.strip()}"
+                        ),
+                    }
+                )
+                notices.append("Included condensed conversation history in the prompt.")
+            for exchange in self.exchanges:
+                messages.extend(
+                    [
+                        {
+                            "role": "user",
+                            "content": f"Earlier question: {exchange.question.strip()}",
+                        },
+                        {
+                            "role": "assistant",
+                            "content": f"Earlier answer: {exchange.answer.strip()}",
+                        },
+                    ]
+                )
+                if exchange.plan:
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": (
+                                "Analysis plan used for the previous answer:\n"
+                                f"{exchange.plan.strip()}"
+                            ),
+                        }
+                    )
+
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"Question: {question.strip()}\n\nContext (JSON):\n{context_json}"
+                ),
+            }
+        )
+        return messages, notices
+
+    def build_plan_messages(
+        self,
+        *,
+        system_prompt: str,
+        question: str,
+        context_json: str,
+    ) -> list[Mapping[str, str]]:
+        """Create a planning prompt that keeps the request concise."""
+
+        messages: list[Mapping[str, str]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an operations assistant that prepares concise analysis plans "
+                    "for another assistant. Focus on highlighting the specific Portainer "
+                    "metrics the second assistant should inspect."
+                ),
+            }
+        ]
+        if self.summary:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        "Conversation summary so far:\n"
+                        f"{self.summary.strip()}"
+                    ),
+                }
+            )
+        for exchange in self.exchanges:
+            messages.extend(
+                [
+                    {
+                        "role": "user",
+                        "content": f"Earlier question: {exchange.question.strip()}",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"Earlier answer: {exchange.answer.strip()}",
+                    },
+                ]
+            )
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    "Draft a short bullet list describing how to answer the following question. "
+                    "Call out the most relevant tables, environments, or metrics from the "
+                    "provided context so the answering assistant can stay within the token budget.\n\n"
+                    f"Question: {question.strip()}\n\nContext (JSON):\n{context_json}"
+                ),
+            }
+        )
+        return messages
+
+    def to_state(self) -> dict[str, object]:
+        """Serialise the history for storage in ``st.session_state``."""
+
+        return {
+            "max_turns": self.max_turns,
+            "summary_token_budget": self.summary_token_budget,
+            "summary": self.summary,
+            "exchanges": [
+                {
+                    "question": exchange.question,
+                    "answer": exchange.answer,
+                    "plan": exchange.plan,
+                }
+                for exchange in self.exchanges
+            ],
+        }
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, object] | None) -> "ConversationHistory":
+        """Restore a history instance from ``st.session_state`` data."""
+
+        history = cls()
+        if not state:
+            return history
+        history.max_turns = int(state.get("max_turns", history.max_turns))
+        history.summary_token_budget = int(
+            state.get("summary_token_budget", history.summary_token_budget)
+        )
+        history.summary = str(state.get("summary", ""))
+        exchanges_state = state.get("exchanges", [])
+        if isinstance(exchanges_state, Iterable):
+            for item in exchanges_state:
+                if not isinstance(item, Mapping):
+                    continue
+                history.exchanges.append(
+                    ConversationExchange(
+                        question=str(item.get("question", "")),
+                        answer=str(item.get("answer", "")),
+                        plan=str(item.get("plan")) if item.get("plan") is not None else None,
+                    )
+                )
+        history._enforce_limits()
+        return history
+
+    def _enforce_limits(self) -> None:
+        """Ensure the retained window and summary respect current limits."""
+
+        while len(self.exchanges) > self.max_turns:
+            removed = self.exchanges.pop(0)
+            snippet = self._format_summary_snippet(removed)
+            if snippet:
+                if self.summary:
+                    self.summary += "\n"
+                self.summary += snippet
+                self.summary = _truncate_to_budget(self.summary, self.summary_token_budget)
+
+        if self.summary_token_budget <= 0:
+            self.summary = ""
+        else:
+            self.summary = _truncate_to_budget(self.summary, self.summary_token_budget)
+
+    @staticmethod
+    def _format_summary_snippet(exchange: ConversationExchange) -> str:
+        question = exchange.question.strip()
+        answer = exchange.answer.strip()
+        plan = (exchange.plan or "").strip()
+        parts = [
+            f"Q: {question}" if question else "",
+            f"A: {answer}" if answer else "",
+            f"Plan: {plan}" if plan else "",
+        ]
+        filtered = [part for part in parts if part]
+        return " \u2013 ".join(filtered)
+

--- a/docs/llm_context_management.md
+++ b/docs/llm_context_management.md
@@ -1,0 +1,49 @@
+# LLM Context Management Strategies
+
+Large language models (LLMs) such as the ones exposed through Ollama have fixed context windows. When you exceed that window the model begins to forget older tokens or fails altogether. The strategies below outline architectural approaches that keep a conversation productive without constantly hitting the limit.
+
+## 1. Build a Retrieval Layer for Long-Term Memory
+- **Structured storage**: Persist prior interactions or domain documents in a vector store (FAISS, ChromaDB, LanceDB) or even a relational database when metadata is more important than semantic search.
+- **Hybrid retrieval**: Combine vector similarity with keyword or metadata filters so you only surface the most relevant chunks for the current user prompt.
+- **Chunking guidance**: Pre-split documents into 500–1500 token passages, store embeddings per chunk, and keep references back to the source so you can cite or refresh data later.
+
+At runtime, turn the user prompt (plus optional conversation summary) into a search query, pull only the top `k` chunks, and compose a prompt template that injects those snippets. This keeps the live conversation inside the context window while still giving the assistant deep knowledge.
+
+## 2. Summarise Conversation History
+- **Rolling summary**: Keep a running synopsis of the chat that you update every few turns. Store the full history separately for audit purposes, but only feed the latest summary and the last few raw turns back to the model.
+- **Map–reduce summarisation**: For very long histories, summarise in stages—summaries of each segment followed by a higher-level synthesis. Updating the top-level summary only when the topic shifts reduces computation.
+- **User intent extraction**: Track explicit goals, preferences, or constraints in structured fields (e.g., JSON) derived from the conversation. Inject just those fields into later prompts instead of lengthy dialogue.
+
+## 3. Use Tooling and Function Calling
+- **External tools**: Offload calculations, lookups, or data transforms to deterministic services or scripts. The LLM only receives the results, which are much shorter than raw datasets.
+- **Function-call planning**: Let the model emit structured intents (tool name + arguments). The orchestrator executes the tool and feeds the response back. This breaks tasks into smaller, context-friendly exchanges.
+
+## 4. Stage Requests Across Multiple Prompts
+- **Hierarchical prompting**: First ask the model to outline an approach, then feed the outline (or pieces of it) into follow-up prompts for expansion. Each step stays within the window.
+- **Iterative refinement**: Instead of sending an entire document, iteratively ask the model to improve or comment on individual sections. Maintain state in your application logic.
+
+## 5. Guardrails and Budgeting
+- **Token accounting**: Estimate prompt sizes before sending them. Libraries such as `tiktoken` can predict token counts so you can trim or summarise proactively.
+- **Adaptive truncation**: If a prompt risks overflow, fall back to a shorter set of retrieved chunks or more aggressive summarisation.
+- **User feedback**: Inform users when the system had to drop context, and offer links to the archived full history when appropriate.
+
+## 6. Streaming and Incremental Generation
+- **Chunked output processing**: Stream model output and, if needed, summarise intermediate results while the generation is still running.
+- **Stateful pipelines**: Combine summarised prior steps with new user input to iteratively refine the final answer without re-sending the entire history each time.
+
+## 7. Persistent Knowledge Bases
+When users frequently refer to the same documents or project state, ingest them once into your retrieval layer. Teach the application to refresh embeddings whenever the source changes, and to cite sources so the model’s answers remain auditable.
+
+---
+
+Implementing even two or three of these patterns will usually keep your Ollama-powered assistant under the context limit while delivering more consistent answers.
+
+## Where to Start: Strategies You Can DIY
+
+If you are wondering which ideas deliver the fastest payoff without introducing heavy infrastructure, focus on the following:
+
+1. **Summarise conversation history** – Storing a rolling summary plus the last few verbatim turns can live entirely inside your application code and a lightweight database (even SQLite). Implementing this pattern usually takes only a small helper function to maintain the summary and a guard that trims the raw transcript.
+2. **Stage requests across multiple prompts** – Prompt decomposition is an orchestration problem, not a tooling one. You can experiment with multi-step prompting today by adding new controller logic that sends an outline prompt, captures the reply, and issues follow-up prompts for each section.
+3. **Token budgeting guardrails** – Libraries such as `tiktoken` or `transformers` can estimate token counts locally. A quick pre-flight check before each call lets you short-circuit or trigger summarisation without any backend changes.
+
+These tactics require minimal external dependencies yet provide significant relief from context pressure. Retrieval-augmented generation, persistent knowledge bases, and sophisticated tool-calling often demand additional services (vector databases, message queues, secure credential handling), so plan for more engineering effort before adopting them.

--- a/tests/test_llm_workflow.py
+++ b/tests/test_llm_workflow.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from app.services.llm_workflow import ConversationHistory, QueryStrategy
+
+
+def test_conversation_history_summarises_old_turns() -> None:
+    history = ConversationHistory(max_turns=2, summary_token_budget=200)
+    history.record_exchange("Q1", "A1")
+    history.record_exchange("Q2", "A2")
+    history.record_exchange("Q3", "A3")
+
+    retained = list(history.iter_recent_exchanges())
+    assert len(retained) == 2
+    assert retained[0].question == "Q2"
+    assert "Q: Q1" in history.summary
+
+
+def test_build_answer_messages_adds_summary_and_history() -> None:
+    history = ConversationHistory(max_turns=2, summary_token_budget=200)
+    history.summary = "Earlier conversation summary"
+    history.record_exchange("Why did the container restart?", "It was updated.")
+
+    messages, notices = history.build_answer_messages(
+        strategy=QueryStrategy.SUMMARY,
+        system_prompt="system prompt",
+        question="What should we check next?",
+        context_json="{}",
+        plan=None,
+    )
+
+    assert any(
+        message["role"] == "system" and "Conversation summary" in message["content"]
+        for message in messages
+    )
+    assert any(message["role"] == "user" for message in messages)
+    assert any(message["role"] == "assistant" for message in messages)
+    assert notices, "Summary strategy should record that conversation context was included"
+
+
+def test_build_plan_messages_include_context() -> None:
+    history = ConversationHistory()
+    history.record_exchange("Previous question", "Previous answer", plan="Previous plan")
+
+    plan_messages = history.build_plan_messages(
+        system_prompt="system", question="Check disk usage", context_json="{\"foo\": \"bar\"}"
+    )
+
+    assert plan_messages[0]["role"] == "system"
+    assert any(message["role"] == "user" and "Check disk usage" in message["content"] for message in plan_messages)
+    assert "{\"foo\": \"bar\"}" in plan_messages[-1]["content"]


### PR DESCRIPTION
## Summary
- add a conversation workflow helper that tracks exchanges, summarises old turns, and builds prompts for direct, summary, and staged strategies
- expose strategy selection plus conversation retention controls in the LLM assistant so operators can tune how much history is replayed
- run staged planning calls before the final answer when requested and persist the resulting plan, answer, and history in session state

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fc1e64d08333ba455a9c900ce58d