### PR TITLE
Reduce Portainer API load by gating heavy data fetches

### DIFF
--- a/app/environment_cache.py
+++ b/app/environment_cache.py
@@ -124,7 +124,11 @@ def _hash_api_key(value: str) -> str:
 
 
 def build_cache_key(
-    environments: Iterable[PortainerEnvironment], *, include_stopped: bool
+    environments: Iterable[PortainerEnvironment],
+    *,
+    include_stopped: bool,
+    include_container_details: bool,
+    include_resource_utilisation: bool,
 ) -> str:
     """Build a deterministic cache key for the provided environments."""
 
@@ -142,6 +146,8 @@ def build_cache_key(
         )
     payload = {
         "include_stopped": include_stopped,
+        "include_container_details": include_container_details,
+        "include_resource_utilisation": include_resource_utilisation,
         "environments": signature,
     }
     raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -335,7 +335,12 @@ except NoEnvironmentsConfiguredError:
     st.stop()
 
 try:
-    data_result = load_portainer_data(configured_environments, include_stopped=True)
+    data_result = load_portainer_data(
+        configured_environments,
+        include_stopped=True,
+        include_container_details=True,
+        include_resource_utilisation=True,
+    )
 except PortainerAPIError as exc:
     st.error(f"Failed to load data from Portainer: {exc}")
     st.stop()

--- a/tests/test_dashboard_state.py
+++ b/tests/test_dashboard_state.py
@@ -288,6 +288,50 @@ def test_fetch_portainer_payload_normalises_swagger_fixture(monkeypatch):
     monkeypatch.setattr(dashboard_state, "PortainerClient", FakePortainerClient)
 
     (
+        stack_df_min,
+        container_df_min,
+        endpoint_df_min,
+        container_details_min,
+        host_df_min,
+        volume_df_min,
+        image_df_min,
+        warnings_min,
+    ) = dashboard_state._fetch_portainer_payload(
+        (environment,),
+        include_stopped=False,
+        include_container_details=False,
+        include_resource_utilisation=False,
+    )
+
+    assert stack_calls == [101, 102]
+    assert container_calls == [(101, False), (102, False)]
+    assert inspect_calls == []
+    assert stats_calls == []
+    assert host_info_calls == []
+    assert host_usage_calls == []
+    assert volume_calls == []
+    assert image_calls == []
+
+    assert warnings_min == []
+    assert container_details_min["cpu_percent"].dropna().empty
+    assert container_details_min["memory_percent"].dropna().empty
+    assert container_details_min["health_status"].dropna().empty
+    if not host_df_min.empty:
+        assert host_df_min["total_cpus"].dropna().empty
+        assert host_df_min["containers_total"].dropna().empty
+    assert volume_df_min.empty
+    assert image_df_min.empty
+
+    stack_calls.clear()
+    container_calls.clear()
+    inspect_calls.clear()
+    stats_calls.clear()
+    host_info_calls.clear()
+    host_usage_calls.clear()
+    volume_calls.clear()
+    image_calls.clear()
+
+    (
         stack_df,
         container_df,
         endpoint_df,
@@ -296,7 +340,12 @@ def test_fetch_portainer_payload_normalises_swagger_fixture(monkeypatch):
         volume_df,
         image_df,
         warnings,
-    ) = dashboard_state._fetch_portainer_payload((environment,), include_stopped=False)
+    ) = dashboard_state._fetch_portainer_payload(
+        (environment,),
+        include_stopped=False,
+        include_container_details=True,
+        include_resource_utilisation=True,
+    )
 
     assert stack_calls == [101, 102]
     assert container_calls == [(101, False), (102, False)]


### PR DESCRIPTION
## Summary
- make heavy Portainer inspect, stats, host, volume, and image queries opt-in so default dashboards perform fewer API calls
- extend caching and background refresh logic to account for the new data scope flags while keeping persistent payloads consistent
- update the LLM assistant to request the richer data set and expand tests to cover both lightweight and full fetches

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e54d6406488333a3b95d0a3414be6a