### PR TITLE
Fix LLM assistant rerun call

### DIFF
--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -613,7 +613,7 @@ with assistant_tab:
                 st.session_state["llm_max_tokens"] = max_tokens
                 st.session_state["llm_verify_ssl"] = verify_ssl
                 st.session_state["llm_max_requests"] = max_requests
-                st.experimental_rerun()
+                st.rerun()
 
 with data_tab:
     st.markdown("### Tables available to the assistant")


### PR DESCRIPTION
## Summary
- replace the deprecated `st.experimental_rerun()` usage with the supported `st.rerun()` call in the LLM assistant page to prevent runtime errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5571c24208333a01a2730bf3cb9d8