### PR TITLE
Improve Portainer client resiliency and settings UX

### DIFF
--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -178,26 +178,43 @@ if st.session_state.get(prev_selection_key) != selection:
     st.session_state["portainer_env_form_verify_ssl"] = (
         bool(selected_env.get("verify_ssl", True)) if selected_env else True
     )
+    st.session_state["portainer_env_form_show_api_key"] = False
 
 st.session_state.setdefault("portainer_env_form_name", "")
 st.session_state.setdefault("portainer_env_form_api_url", "")
 st.session_state.setdefault("portainer_env_form_api_key", "")
 st.session_state.setdefault("portainer_env_form_verify_ssl", True)
+st.session_state.setdefault("portainer_env_form_show_api_key", False)
 
 form_error: str | None = None
 test_connection_clicked = False
 with st.form("portainer_env_form"):
     st.text_input("Name", key="portainer_env_form_name")
     st.text_input("API URL", key="portainer_env_form_api_url")
+    st.checkbox(
+        "Show API key",
+        key="portainer_env_form_show_api_key",
+        help="Temporarily reveal the API key in this session.",
+    )
     st.text_input(
         "API key",
         key="portainer_env_form_api_key",
-        type="password",
+        type=(
+            "default"
+            if st.session_state.get("portainer_env_form_show_api_key")
+            else "password"
+        ),
     )
     st.checkbox(
         "Verify SSL certificates",
         key="portainer_env_form_verify_ssl",
     )
+    if not st.session_state.get("portainer_env_form_verify_ssl", True):
+        st.warning(
+            "SSL certificate verification is disabled. Only use this for trusted "
+            "internal installations.",
+            icon="⚠️",
+        )
     save_col, test_col = st.columns(2)
     with save_col:
         submitted = st.form_submit_button(

--- a/tests/test_portainer_client.py
+++ b/tests/test_portainer_client.py
@@ -82,19 +82,17 @@ def test_create_backup_posts_to_backup_endpoint(monkeypatch):
         def raise_for_status() -> None:
             return None
 
-    def fake_post(url, headers, json, timeout, verify):  # type: ignore[override]
+    def fake_post(url, *, json=None, timeout=None):  # type: ignore[override]
         captured.update(
             {
                 "url": url,
-                "headers": headers,
                 "json": json,
                 "timeout": timeout,
-                "verify": verify,
             }
         )
         return DummyResponse()
 
-    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
+    monkeypatch.setattr(client._session, "post", fake_post)
 
     payload, filename = client.create_backup(password="secret")
 
@@ -102,6 +100,7 @@ def test_create_backup_posts_to_backup_endpoint(monkeypatch):
     assert captured["json"] == {"password": "secret"}
     assert payload == b"backup-data"
     assert filename == "portainer.tar.gz"
+    assert client._session.headers["X-API-Key"] == "token"
 
 
 def test_get_stack_image_status(monkeypatch):
@@ -131,7 +130,7 @@ def test_create_backup_raises_on_request_errors(monkeypatch):
     def fake_post(*args, **kwargs):  # type: ignore[override]
         raise requests.RequestException("boom")
 
-    monkeypatch.setattr(portainer_client.requests, "post", fake_post)
+    monkeypatch.setattr(client._session, "post", fake_post)
 
     with pytest.raises(PortainerAPIError):
         client.create_backup()


### PR DESCRIPTION
## Summary
- reuse a persistent requests session with retry/backoff in the Portainer client and surface logging when SSL verification is disabled
- allow operators to toggle API key visibility and show warnings when SSL checks are turned off in the settings page
- update unit tests to exercise the new session behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e58591c79c83339f949ae1a5a1dbbc