### PR TITLE
Add OIDC authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ The application is configured via environment variables:
 - `PORTAINER_VERIFY_SSL` – Optional. Set to `false` to disable TLS certificate verification when using self-signed certificates.
 - `DASHBOARD_USERNAME` – Username required to sign in to the dashboard UI.
 - `DASHBOARD_KEY` – Access key (password) required to sign in to the dashboard UI.
+- `DASHBOARD_AUTH_PROVIDER` – Optional. Set to `oidc` to enable OpenID Connect single sign-on. Defaults to `static`, which uses the username/key form above.
 - `DASHBOARD_SESSION_TIMEOUT_MINUTES` – Optional. Expire authenticated sessions after the specified number of minutes of inactivity. Omit or set to a non-positive value to disable the timeout.
 - `DASHBOARD_LOG_LEVEL` – Optional. Overrides the log verbosity for the dashboard. Accepts standard Python levels (e.g. `INFO`, `DEBUG`, `ERROR`) plus `TRACE`/`VERBOSE`. Defaults to `INFO` when unset or invalid.
+- `DASHBOARD_OIDC_ISSUER` – Required when `DASHBOARD_AUTH_PROVIDER=oidc`. Base issuer URL advertised by your identity provider.
+- `DASHBOARD_OIDC_CLIENT_ID` – Required when `DASHBOARD_AUTH_PROVIDER=oidc`. OAuth client identifier registered with the provider.
+- `DASHBOARD_OIDC_CLIENT_SECRET` – Optional. Client secret issued by the provider. Omit for public clients using PKCE only.
+- `DASHBOARD_OIDC_REDIRECT_URI` – Required when `DASHBOARD_AUTH_PROVIDER=oidc`. Callback URL configured for the dashboard client (for example `https://dashboard.example.com/`).
+- `DASHBOARD_OIDC_SCOPES` – Optional. Space-separated list of scopes to request during login. Defaults to `openid profile email` and always ensures the mandatory `openid` scope is requested.
+- `DASHBOARD_OIDC_DISCOVERY_URL` – Optional. Overrides the OIDC discovery document URL. When unset the dashboard fetches `{issuer}/.well-known/openid-configuration` automatically.
+- `DASHBOARD_OIDC_AUDIENCE` – Optional. Audience value to enforce when validating ID tokens. Defaults to the configured client ID.
 - `PORTAINER_CACHE_ENABLED` – Optional. Defaults to `true`. Set to `false` to disable persistent caching of Portainer API responses between sessions.
 - `PORTAINER_CACHE_TTL_SECONDS` – Optional. Number of seconds before cached Portainer API responses are refreshed. Defaults to 900 seconds (15 minutes). Set to `0` or a negative value to keep cached data until it is manually invalidated.
 - `PORTAINER_CACHE_DIR` – Optional. Directory used to persist cached Portainer data. Defaults to `.streamlit/cache` inside the application directory.
@@ -27,8 +35,7 @@ The application is configured via environment variables:
 - `KIBANA_VERIFY_SSL` – Optional. Defaults to `true`. Set to `false` to skip TLS verification when connecting to Kibana with self-signed certificates.
 - `KIBANA_TIMEOUT_SECONDS` – Optional. Request timeout (in seconds) for Kibana log queries. Defaults to 30 seconds when unset or invalid.
 
-Both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be set. When they are missing, the app blocks access and displays an error so
-operators can fix the configuration before exposing the dashboard.
+When `DASHBOARD_AUTH_PROVIDER` is unset or set to `static`, both `DASHBOARD_USERNAME` and `DASHBOARD_KEY` must be provided. The app blocks access and displays an error until those credentials are configured. When `DASHBOARD_AUTH_PROVIDER=oidc`, configure the matching `DASHBOARD_OIDC_*` variables instead—the dashboard redirects users through the standard authorization-code flow, discovers the provider endpoints via the well-known document, and validates ID tokens against the advertised JWKS before establishing a session.
 
 After signing in, operators can use the persistent **Log out** button in the sidebar to clear their authentication session when
 they step away from the dashboard. When a session timeout is configured, the remaining time is shown in the sidebar so

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,22 +1,61 @@
 """Authentication utilities for the Streamlit dashboard."""
 from __future__ import annotations
 
+import base64
+import hashlib
+import html
+import json
 import math
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from secrets import token_urlsafe
 from functools import lru_cache
-from typing import Dict, Optional
+from secrets import token_urlsafe
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
 
+import jwt
+import requests
 import streamlit as st
 from streamlit_autorefresh import st_autorefresh
 
 USERNAME_ENV_VAR = "DASHBOARD_USERNAME"
 KEY_ENV_VAR = "DASHBOARD_KEY"
 SESSION_TIMEOUT_ENV_VAR = "DASHBOARD_SESSION_TIMEOUT_MINUTES"
+AUTH_PROVIDER_ENV_VAR = "DASHBOARD_AUTH_PROVIDER"
+OIDC_ISSUER_ENV_VAR = "DASHBOARD_OIDC_ISSUER"
+OIDC_CLIENT_ID_ENV_VAR = "DASHBOARD_OIDC_CLIENT_ID"
+OIDC_CLIENT_SECRET_ENV_VAR = "DASHBOARD_OIDC_CLIENT_SECRET"
+OIDC_REDIRECT_URI_ENV_VAR = "DASHBOARD_OIDC_REDIRECT_URI"
+OIDC_SCOPES_ENV_VAR = "DASHBOARD_OIDC_SCOPES"
+OIDC_DISCOVERY_URL_ENV_VAR = "DASHBOARD_OIDC_DISCOVERY_URL"
+OIDC_AUDIENCE_ENV_VAR = "DASHBOARD_OIDC_AUDIENCE"
 SESSION_COOKIE_NAME = "dashboard_session_token"
 DEFAULT_SESSION_COOKIE_DURATION = timedelta(days=30)
+
+
+@dataclass(frozen=True)
+class _OIDCSettings:
+    """Configuration required to initiate the OIDC authorisation flow."""
+
+    issuer: str
+    client_id: str
+    client_secret: Optional[str]
+    redirect_uri: str
+    scopes: tuple[str, ...]
+    audience: Optional[str]
+    discovery_url: str
+
+
+@dataclass(frozen=True)
+class _OIDCProviderMetadata:
+    """Metadata advertised by the OIDC discovery document."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+    end_session_endpoint: Optional[str]
 
 
 @dataclass
@@ -27,6 +66,7 @@ class _PersistentSession:
     authenticated_at: datetime
     last_active: datetime
     session_timeout: Optional[timedelta]
+    auth_method: str = "static"
 
     def is_expired(self, now: datetime) -> bool:
         """Return ``True`` if the session expired according to the timeout."""
@@ -41,6 +81,461 @@ def _get_persistent_sessions() -> Dict[str, _PersistentSession]:
 
     return {}
 
+
+def _get_auth_provider() -> str:
+    """Return the configured authentication provider identifier."""
+
+    provider = os.getenv(AUTH_PROVIDER_ENV_VAR, "static").strip().lower()
+    if not provider:
+        return "static"
+    return provider
+
+
+def _build_well_known_url(issuer: str) -> str:
+    """Return the OIDC discovery document URL for the given issuer."""
+
+    cleaned = issuer.rstrip("/")
+    return f"{cleaned}/.well-known/openid-configuration"
+
+
+@lru_cache(maxsize=8)
+def _load_oidc_provider_metadata(discovery_url: str) -> _OIDCProviderMetadata:
+    """Fetch and parse the OIDC provider discovery document."""
+
+    try:
+        response = requests.get(discovery_url, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ValueError(
+            "Failed to retrieve OIDC discovery document. Check the issuer URL and network connectivity."
+        ) from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError("OIDC discovery response was not valid JSON.") from exc
+
+    for field in ("authorization_endpoint", "token_endpoint", "jwks_uri"):
+        if field not in payload:
+            raise ValueError(
+                "OIDC discovery document is missing the required "
+                f"'{field}' attribute."
+            )
+
+    issuer = payload.get("issuer") or discovery_url
+    return _OIDCProviderMetadata(
+        issuer=issuer,
+        authorization_endpoint=payload["authorization_endpoint"],
+        token_endpoint=payload["token_endpoint"],
+        jwks_uri=payload["jwks_uri"],
+        end_session_endpoint=payload.get("end_session_endpoint"),
+    )
+
+
+@lru_cache(maxsize=8)
+def _fetch_oidc_jwks(jwks_uri: str) -> dict[str, Any]:
+    """Fetch the JSON Web Key Set used to validate ID token signatures."""
+
+    try:
+        response = requests.get(jwks_uri, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ValueError("Failed to download OIDC JWKS from the provider.") from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError("OIDC JWKS response was not valid JSON.") from exc
+
+    keys = payload.get("keys")
+    if not isinstance(keys, list) or not keys:
+        raise ValueError("OIDC JWKS payload did not include signing keys.")
+
+    return payload
+
+
+def _normalise_scopes(raw_scopes: str | None) -> tuple[str, ...]:
+    """Return a normalised list of scopes ensuring ``openid`` is included."""
+
+    if not raw_scopes:
+        scopes: list[str] = ["openid", "profile", "email"]
+    else:
+        scopes = [scope for scope in raw_scopes.replace(",", " ").split() if scope]
+        if "openid" not in scopes:
+            scopes.insert(0, "openid")
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for scope in scopes:
+        if scope in seen:
+            continue
+        seen.add(scope)
+        deduped.append(scope)
+    return tuple(deduped)
+
+
+def _get_oidc_settings() -> _OIDCSettings:
+    """Load the configured OIDC settings from the environment."""
+
+    issuer = os.getenv(OIDC_ISSUER_ENV_VAR, "").strip()
+    if not issuer:
+        raise ValueError(
+            "OIDC authentication is enabled but the issuer URL is missing. "
+            f"Set `{OIDC_ISSUER_ENV_VAR}` to your identity provider issuer."
+        )
+
+    client_id = os.getenv(OIDC_CLIENT_ID_ENV_VAR, "").strip()
+    if not client_id:
+        raise ValueError(
+            "OIDC authentication is enabled but the client ID is missing. "
+            f"Set `{OIDC_CLIENT_ID_ENV_VAR}` to your registered client ID."
+        )
+
+    redirect_uri = os.getenv(OIDC_REDIRECT_URI_ENV_VAR, "").strip()
+    if not redirect_uri:
+        raise ValueError(
+            "OIDC authentication requires a redirect URI. Set "
+            f"`{OIDC_REDIRECT_URI_ENV_VAR}` to the callback URL configured in your identity provider."
+        )
+
+    discovery_url = os.getenv(OIDC_DISCOVERY_URL_ENV_VAR, "").strip()
+    if not discovery_url:
+        discovery_url = _build_well_known_url(issuer)
+
+    client_secret = os.getenv(OIDC_CLIENT_SECRET_ENV_VAR)
+    if client_secret is not None:
+        client_secret = client_secret.strip() or None
+
+    scopes = _normalise_scopes(os.getenv(OIDC_SCOPES_ENV_VAR))
+    audience = os.getenv(OIDC_AUDIENCE_ENV_VAR, "").strip() or None
+
+    return _OIDCSettings(
+        issuer=issuer.rstrip("/"),
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        scopes=scopes,
+        audience=audience,
+        discovery_url=discovery_url,
+    )
+
+
+def _select_jwk(jwks: dict[str, Any], *, kid: Optional[str]) -> dict[str, Any]:
+    """Return the signing key matching ``kid`` from the JWKS payload."""
+
+    keys = jwks.get("keys", [])
+    if not isinstance(keys, list):
+        raise ValueError("OIDC JWKS payload is malformed.")
+
+    if kid is None:
+        if len(keys) == 1:
+            return keys[0]
+        raise ValueError("ID token did not specify a key identifier (kid).")
+
+    for key in keys:
+        if not isinstance(key, dict):
+            continue
+        if key.get("kid") == kid:
+            return key
+
+    raise ValueError("Unable to find a signing key that matches the ID token.")
+
+
+def _verify_id_token(settings: _OIDCSettings, id_token: str) -> dict[str, Any]:
+    """Validate the ID token signature and required claims."""
+
+    metadata = _load_oidc_provider_metadata(settings.discovery_url)
+    jwks = _fetch_oidc_jwks(metadata.jwks_uri)
+
+    try:
+        header = jwt.get_unverified_header(id_token)
+    except jwt.InvalidTokenError as exc:
+        raise ValueError("Unable to parse ID token header.") from exc
+
+    algorithm_name = header.get("alg")
+    if not isinstance(algorithm_name, str):
+        raise ValueError("ID token is missing the signing algorithm.")
+
+    algorithms = jwt.algorithms.get_default_algorithms()
+    algorithm = algorithms.get(algorithm_name)
+    if algorithm is None:
+        raise ValueError(f"Unsupported ID token signing algorithm: {algorithm_name}.")
+
+    key_data = _select_jwk(jwks, kid=header.get("kid"))
+    key = algorithm.from_jwk(json.dumps(key_data))
+
+    audience = settings.audience or settings.client_id
+
+    try:
+        return jwt.decode(
+            id_token,
+            key,
+            algorithms=[algorithm_name],
+            audience=audience,
+            issuer=settings.issuer,
+            options={"require": ["sub", "iss", "aud", "exp", "iat"]},
+        )
+    except jwt.InvalidTokenError as exc:
+        raise ValueError("The ID token from the provider could not be validated.") from exc
+
+
+def _build_authorization_url(
+    metadata: _OIDCProviderMetadata,
+    settings: _OIDCSettings,
+    *,
+    state: str,
+    code_challenge: Optional[str],
+) -> str:
+    """Construct the OIDC authorisation endpoint URL."""
+
+    params: dict[str, str] = {
+        "response_type": "code",
+        "client_id": settings.client_id,
+        "redirect_uri": settings.redirect_uri,
+        "scope": " ".join(settings.scopes),
+        "state": state,
+    }
+    if code_challenge is not None:
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = "S256"
+    query = urlencode(params)
+    separator = "&" if "?" in metadata.authorization_endpoint else "?"
+    return f"{metadata.authorization_endpoint}{separator}{query}"
+
+
+def _generate_code_verifier() -> str:
+    """Return a cryptographically random code verifier for PKCE."""
+
+    return token_urlsafe(96)
+
+
+def _create_code_challenge(verifier: str) -> str:
+    """Create a S256 code challenge from ``verifier`` suitable for PKCE."""
+
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _generate_state_token() -> str:
+    """Return a secure random state token for the OIDC flow."""
+
+    return token_urlsafe(32)
+
+
+def _get_query_param(name: str) -> Optional[str]:
+    """Return the first value for the given query parameter, if present."""
+
+    try:
+        params = st.query_params  # type: ignore[attr-defined]
+        value = params.get(name)
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return value[0] if value else None
+        return str(value)
+    except AttributeError:
+        params = st.experimental_get_query_params()
+        values = params.get(name)
+        if not values:
+            return None
+        return values[0]
+
+
+def _clear_query_params() -> None:
+    """Remove all query parameters from the current page URL."""
+
+    try:
+        st.query_params.clear()  # type: ignore[attr-defined]
+    except AttributeError:
+        st.experimental_set_query_params()
+
+
+def _redirect_to_authorization(url: str) -> None:
+    """Perform a client-side redirect to the identity provider."""
+
+    escaped = html.escape(url, quote=True)
+    st.markdown(
+        f'<meta http-equiv="refresh" content="0; url={escaped}">',
+        unsafe_allow_html=True,
+    )
+    st.stop()
+
+
+def _exchange_code_for_tokens(
+    metadata: _OIDCProviderMetadata,
+    settings: _OIDCSettings,
+    *,
+    code: str,
+    code_verifier: Optional[str],
+) -> dict[str, Any]:
+    """Exchange the received authorisation code for tokens."""
+
+    data: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": settings.redirect_uri,
+        "client_id": settings.client_id,
+    }
+    if code_verifier:
+        data["code_verifier"] = code_verifier
+
+    auth: Optional[tuple[str, str]] = None
+    if settings.client_secret:
+        auth = (settings.client_id, settings.client_secret)
+
+    try:
+        response = requests.post(
+            metadata.token_endpoint,
+            data=data,
+            auth=auth,
+            timeout=10,
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ValueError("Failed to exchange the authorisation code for tokens.") from exc
+
+    try:
+        token_payload = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError("Token endpoint returned an invalid JSON response.") from exc
+
+    return token_payload
+
+
+def _extract_display_name(claims: dict[str, Any]) -> str:
+    """Return a human-friendly display name from the ID token claims."""
+
+    for key in ("name", "preferred_username", "email", "sub"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return "Authenticated user"
+
+
+def _handle_oidc_callback(
+    settings: _OIDCSettings,
+    session_timeout: Optional[timedelta],
+    now: datetime,
+) -> None:
+    """Process an authorisation response from the identity provider."""
+
+    code = _get_query_param("code")
+    state = _get_query_param("state")
+    error = _get_query_param("error")
+
+    if error:
+        description = _get_query_param("error_description")
+        message = f"OIDC provider returned an error: {error}"
+        if description:
+            message = f"{message} – {description}"
+        st.session_state["auth_error"] = message
+        _clear_query_params()
+        _trigger_rerun()
+        return
+
+    if not code:
+        return
+
+    expected_state = st.session_state.get("_oidc_state")
+    if not isinstance(expected_state, str) or state != expected_state:
+        st.session_state["auth_error"] = "Invalid login response. Please try again."
+        _clear_query_params()
+        _trigger_rerun()
+        return
+
+    code_verifier = st.session_state.get("_oidc_code_verifier")
+    if code_verifier is not None and not isinstance(code_verifier, str):
+        code_verifier = None
+
+    metadata = _load_oidc_provider_metadata(settings.discovery_url)
+
+    try:
+        token_payload = _exchange_code_for_tokens(
+            metadata,
+            settings,
+            code=code,
+            code_verifier=code_verifier,
+        )
+    except ValueError as exc:
+        st.session_state["auth_error"] = str(exc)
+        _clear_query_params()
+        _trigger_rerun()
+        return
+
+    id_token = token_payload.get("id_token")
+    if not isinstance(id_token, str) or not id_token:
+        st.session_state["auth_error"] = (
+            "The identity provider response did not include an ID token."
+        )
+        _clear_query_params()
+        _trigger_rerun()
+        return
+
+    try:
+        claims = _verify_id_token(settings, id_token)
+    except ValueError as exc:
+        st.session_state["auth_error"] = str(exc)
+        _clear_query_params()
+        _trigger_rerun()
+        return
+
+    display_name = _extract_display_name(claims)
+
+    st.session_state["authenticated"] = True
+    st.session_state["authenticated_at"] = now
+    st.session_state["last_active"] = now
+    st.session_state["auth_method"] = "oidc"
+    st.session_state["display_name"] = display_name
+    st.session_state["oidc_claims"] = claims
+    st.session_state["oidc_id_token"] = id_token
+    st.session_state.pop("auth_error", None)
+    st.session_state.pop("_oidc_state", None)
+    st.session_state.pop("_oidc_code_verifier", None)
+
+    _store_persistent_session(
+        display_name,
+        now,
+        session_timeout,
+        auth_method="oidc",
+    )
+
+    _clear_query_params()
+    _trigger_rerun()
+
+
+def _render_oidc_login(settings: _OIDCSettings) -> None:
+    """Render the OIDC login button and initiate the flow when clicked."""
+
+    st.markdown("### 🔐 Sign in to the Portainer dashboard")
+    st.caption("Use your identity provider credentials to continue.")
+
+    error_message = st.session_state.get("auth_error")
+    if error_message:
+        st.error(error_message)
+
+    if st.button("Continue with single sign-on", key="oidc_sign_in", type="primary"):
+        try:
+            metadata = _load_oidc_provider_metadata(settings.discovery_url)
+        except ValueError as exc:
+            st.session_state["auth_error"] = str(exc)
+            _trigger_rerun()
+            return
+
+        state_token = _generate_state_token()
+        code_verifier = _generate_code_verifier()
+        code_challenge = _create_code_challenge(code_verifier)
+        st.session_state["_oidc_state"] = state_token
+        st.session_state["_oidc_code_verifier"] = code_verifier
+        st.session_state.pop("auth_error", None)
+
+        authorization_url = _build_authorization_url(
+            metadata,
+            settings,
+            state=state_token,
+            code_challenge=code_challenge,
+        )
+        _redirect_to_authorization(authorization_url)
 
 def _prune_expired_sessions(*, now: Optional[datetime] = None) -> None:
     """Remove expired sessions from the persistent store."""
@@ -173,7 +668,11 @@ def _clear_persistent_session() -> None:
 
 
 def _store_persistent_session(
-    username: str, now: datetime, session_timeout: Optional[timedelta]
+    username: str,
+    now: datetime,
+    session_timeout: Optional[timedelta],
+    *,
+    auth_method: str = "static",
 ) -> None:
     """Create and persist a new session token for the authenticated user."""
 
@@ -184,6 +683,7 @@ def _store_persistent_session(
         authenticated_at=now,
         last_active=now,
         session_timeout=session_timeout,
+        auth_method=auth_method,
     )
     st.session_state["_session_token"] = token
     _set_session_cookie(token, now=now, session_timeout=session_timeout)
@@ -208,7 +708,9 @@ def _update_persistent_session_activity(
 
 
 def _restore_persistent_session(
-    expected_username: str, session_timeout: Optional[timedelta], now: datetime
+    expected_username: Optional[str],
+    session_timeout: Optional[timedelta],
+    now: datetime,
 ) -> None:
     """Restore an authenticated session based on the persisted token, if present."""
 
@@ -219,7 +721,12 @@ def _restore_persistent_session(
 
     sessions = _get_persistent_sessions()
     session = sessions.get(token)
-    if session is None or session.username != expected_username:
+    if session is None:
+        sessions.pop(token, None)
+        _delete_session_cookie()
+        return
+
+    if expected_username is not None and session.username != expected_username:
         sessions.pop(token, None)
         _delete_session_cookie()
         return
@@ -240,20 +747,20 @@ def _restore_persistent_session(
     st.session_state["authenticated_at"] = session.authenticated_at
     st.session_state["last_active"] = now
     st.session_state["_session_token"] = token
+    st.session_state["auth_method"] = session.auth_method
+    st.session_state["display_name"] = session.username
     _set_session_cookie(token, now=now, session_timeout=session_timeout)
     session.last_active = now
 
 
 def require_authentication() -> None:
     """Prompt the user for credentials and block execution until authenticated."""
-    expected_username = os.getenv(USERNAME_ENV_VAR)
-    expected_key = os.getenv(KEY_ENV_VAR)
 
-    if not expected_username or not expected_key:
+    provider = _get_auth_provider()
+    if provider not in {"static", "oidc"}:
         st.error(
-            "Dashboard credentials are not configured. Set both the "
-            f"`{USERNAME_ENV_VAR}` and `{KEY_ENV_VAR}` environment variables "
-            "before starting the app."
+            "Unsupported authentication provider configured. Set "
+            f"`{AUTH_PROVIDER_ENV_VAR}` to either 'static' or 'oidc'."
         )
         st.stop()
 
@@ -264,9 +771,35 @@ def require_authentication() -> None:
         st.stop()
 
     now = datetime.now(timezone.utc)
-    _restore_persistent_session(expected_username, session_timeout, now)
     session_timer_placeholder = st.sidebar.empty()
     auto_refresh_triggered = False
+
+    oidc_settings: Optional[_OIDCSettings] = None
+    expected_username: Optional[str] = None
+    expected_key: Optional[str] = None
+
+    if provider == "oidc":
+        try:
+            oidc_settings = _get_oidc_settings()
+        except ValueError as exc:
+            st.error(str(exc))
+            st.stop()
+
+        _restore_persistent_session(None, session_timeout, now)
+        _handle_oidc_callback(oidc_settings, session_timeout, now)
+    else:
+        expected_username = os.getenv(USERNAME_ENV_VAR)
+        expected_key = os.getenv(KEY_ENV_VAR)
+
+        if not expected_username or not expected_key:
+            st.error(
+                "Dashboard credentials are not configured. Set both the "
+                f"`{USERNAME_ENV_VAR}` and `{KEY_ENV_VAR}` environment "
+                "variables before starting the app."
+            )
+            st.stop()
+
+        _restore_persistent_session(expected_username, session_timeout, now)
 
     if st.session_state.get("authenticated") and session_timeout is not None:
         refresh_count = st_autorefresh(interval=30000, key="session_timeout_refresh")
@@ -330,6 +863,13 @@ def require_authentication() -> None:
 
     session_timer_placeholder.empty()
 
+    if provider == "oidc":
+        if oidc_settings is None:
+            st.error("OIDC settings could not be loaded.")
+            st.stop()
+        _render_oidc_login(oidc_settings)
+        st.stop()
+
     st.markdown("### 🔐 Sign in to the Portainer dashboard")
     st.caption(
         "Enter the credentials configured through the dashboard environment "
@@ -354,7 +894,14 @@ def require_authentication() -> None:
             st.session_state["authenticated"] = True
             st.session_state["authenticated_at"] = now
             st.session_state["last_active"] = now
-            _store_persistent_session(username, now, session_timeout)
+            st.session_state["auth_method"] = "static"
+            st.session_state["display_name"] = expected_username
+            _store_persistent_session(
+                expected_username,
+                now,
+                session_timeout,
+                auth_method="static",
+            )
             st.session_state.pop("auth_error", None)
             _trigger_rerun()
         else:
@@ -369,8 +916,23 @@ def render_logout_button() -> None:
     if not st.session_state.get("authenticated"):
         return
 
+    display_name = st.session_state.get("display_name")
+    if isinstance(display_name, str) and display_name.strip():
+        st.sidebar.caption(f"Signed in as {display_name}")
+
     if st.sidebar.button("Log out", width="stretch"):
         _clear_persistent_session()
-        for key in ("authenticated", "auth_error"):
+        for key in (
+            "authenticated",
+            "auth_error",
+            "authenticated_at",
+            "last_active",
+            "display_name",
+            "auth_method",
+            "oidc_claims",
+            "oidc_id_token",
+            "_oidc_state",
+            "_oidc_code_verifier",
+        ):
             st.session_state.pop(key, None)
         _trigger_rerun()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.3.3
 plotly==6.3.0
 PyYAML==6.0.3
 python-dotenv==1.1.1
+PyJWT==2.10.1

--- a/tests/test_auth_oidc.py
+++ b/tests/test_auth_oidc.py
@@ -1,0 +1,100 @@
+"""Tests covering the OIDC helpers in :mod:`app.auth`."""
+from __future__ import annotations
+
+import base64
+import time
+
+import pytest
+import jwt
+
+from app import auth
+
+
+def _clear_oidc_caches() -> None:
+    """Reset cached network lookups between tests."""
+
+    auth._load_oidc_provider_metadata.cache_clear()
+    auth._fetch_oidc_jwks.cache_clear()
+
+
+def test_build_well_known_url_handles_trailing_slashes() -> None:
+    assert (
+        auth._build_well_known_url("https://issuer.example.com/")
+        == "https://issuer.example.com/.well-known/openid-configuration"
+    )
+
+
+def test_get_oidc_settings_requires_mandatory_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in (
+        auth.OIDC_ISSUER_ENV_VAR,
+        auth.OIDC_CLIENT_ID_ENV_VAR,
+        auth.OIDC_REDIRECT_URI_ENV_VAR,
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(ValueError):
+        auth._get_oidc_settings()
+
+
+def test_get_oidc_settings_injects_openid_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(auth.OIDC_ISSUER_ENV_VAR, "https://issuer.example.com")
+    monkeypatch.setenv(auth.OIDC_CLIENT_ID_ENV_VAR, "client-id")
+    monkeypatch.setenv(auth.OIDC_REDIRECT_URI_ENV_VAR, "https://app.example.com/callback")
+    monkeypatch.setenv(auth.OIDC_SCOPES_ENV_VAR, "profile email")
+
+    settings = auth._get_oidc_settings()
+
+    assert settings.scopes[0] == "openid"
+    assert "profile" in settings.scopes
+    assert "email" in settings.scopes
+
+
+def test_verify_id_token_uses_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_oidc_caches()
+
+    settings = auth._OIDCSettings(
+        issuer="https://issuer.example.com",
+        client_id="client-id",
+        client_secret=None,
+        redirect_uri="https://app.example.com/callback",
+        scopes=("openid",),
+        audience=None,
+        discovery_url="https://issuer.example.com/.well-known/openid-configuration",
+    )
+
+    metadata = auth._OIDCProviderMetadata(
+        issuer="https://issuer.example.com",
+        authorization_endpoint="https://issuer.example.com/auth",
+        token_endpoint="https://issuer.example.com/token",
+        jwks_uri="https://issuer.example.com/jwks",
+        end_session_endpoint=None,
+    )
+
+    monkeypatch.setattr(auth, "_load_oidc_provider_metadata", lambda _: metadata)
+
+    jwk = {
+        "kid": "kid-1",
+        "kty": "oct",
+        "k": base64.urlsafe_b64encode(b"super-secret").rstrip(b"=").decode("ascii"),
+        "alg": "HS256",
+    }
+    monkeypatch.setattr(auth, "_fetch_oidc_jwks", lambda _: {"keys": [jwk]})
+
+    now = int(time.time())
+    id_token = jwt.encode(
+        {
+            "sub": "user-123",
+            "iss": "https://issuer.example.com",
+            "aud": "client-id",
+            "exp": now + 300,
+            "iat": now,
+        },
+        "super-secret",
+        algorithm="HS256",
+        headers={"kid": "kid-1"},
+    )
+
+    claims = auth._verify_id_token(settings, id_token)
+
+    assert claims["sub"] == "user-123"
+


### PR DESCRIPTION
## Summary
- add an optional OpenID Connect authentication provider with discovery-based configuration, PKCE, and ID token validation
- update the login and logout flows to support OIDC sessions alongside the existing static credential mode
- document the new environment variables, add unit tests for the OIDC helpers, and include the PyJWT dependency

## Testing
- pytest -q
- scripts/check_app_starts.sh

------
https://chatgpt.com/codex/tasks/task_e_68e58b84f4188333acbd989970d811a0