### PR TITLE
Add architecture boundaries documentation for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Thanks for investing time in improving the Streamlit Portainer dashboard! This project already ships with operator-focused documentation; the resources below help you extend the codebase safely.
+
+## Before you start
+
+1. Review the [module boundaries guide](docs/module_boundaries.md) to understand how pages, services, and shared helpers interact.
+2. Skim the existing documentation in `docs/` to see whether your change touches related operational guidance.
+3. Set up a Python 3.12 environment and install the dependencies listed in `requirements.txt`.
+
+## Development tips
+
+- Keep new Streamlit UI in `app/pages/` (or `app/components/` for reusable fragments) and use `app/dashboard_state.py` to coordinate shared state.
+- Place external integrations and background jobs in `app/services/`, ensuring callers interact with the service instead of reimplementing HTTP requests.
+- Extend `app/config/` or `app/settings.py` when introducing new configuration sources so tests and documentation stay consistent.
+- Add or update tests under `tests/` when you change behaviour, especially when touching Portainer, Kibana, or LLM integrations.
+
+## Pull request checklist
+
+Include this lightweight checklist in your pull request description or verify each item before requesting review:
+
+- [ ] Changes respect the [documented module boundaries](docs/module_boundaries.md) (UI → shared helpers → services).
+- [ ] New or modified pages reuse shared components/state instead of duplicating helpers.
+- [ ] Services remain the only layer that calls external APIs or long-running jobs.
+- [ ] Documentation updates accompany new configuration flags, background jobs, or navigation entries.
+- [ ] Tests cover new logic or existing suites remain green (`pytest -q`).
+
+Following these steps keeps the module boundaries clear and helps reviewers focus on the substance of your contribution.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 A streamlit application that pulls information from the Portainer API and visualizes everything.
 
+## Architecture & contributor docs
+
+- [Module boundaries and ownership](docs/module_boundaries.md) – high-level architecture, module responsibilities, and guidance on where to place new functionality.
+- [LLM context management](docs/llm_context_management.md) – explains how prompt construction and trimming works inside the assistant.
+- [Portainer data audit](docs/portainer_data_audit.md) – details the telemetry surfaced for compliance reviews.
+
 ## Configuration
 
 The application is configured via environment variables:

--- a/docs/module_boundaries.md
+++ b/docs/module_boundaries.md
@@ -1,0 +1,112 @@
+# Streamlit Portainer dashboard module boundaries
+
+This guide captures the architectural intent of the dashboard so contributors can make changes without breaking the implicit contracts between modules.
+
+## Module interaction diagram
+
+```mermaid
+flowchart LR
+    subgraph UI_Layer[UI layer]
+        Home[Home.py]
+        Pages[pages/*]
+        Components[components/*]
+    end
+
+    subgraph Shared_Helpers[Shared helpers]
+        Config[config/*\nsettings.py]
+        State[dashboard_state.py]
+        Cache[environment_cache.py]
+        UIHelpers[ui_helpers.py]
+        Utils[utils/*]
+    end
+
+    subgraph Services
+        PortainerSvc[services/portainer_client.py]
+        BackupSvc[services/backup.py\nservices/backup_scheduler.py]
+        LlmSvc[services/llm_client.py\nservices/llm_context.py]
+        KibanaSvc[services/kibana_client.py]
+    end
+
+    subgraph Integrations
+        PortainerAPI[(Portainer API)]
+        KibanaAPI[(Kibana / Elasticsearch)]
+        LlmAPI[(External LLM endpoint)]
+        Storage[(Local cache & backups)]
+    end
+
+    Home --> State
+    Pages --> State
+    Pages --> Components
+    Components --> UIHelpers
+    UIHelpers --> State
+
+    State --> PortainerSvc
+    State --> BackupSvc
+    State --> LlmSvc
+    State --> KibanaSvc
+
+    Config --> State
+    Config --> PortainerSvc
+    Config --> LlmSvc
+    Config --> KibanaSvc
+    Cache --> PortainerSvc
+    Cache --> BackupSvc
+
+    PortainerSvc --> PortainerAPI
+    BackupSvc --> Storage
+    LlmSvc --> LlmAPI
+    KibanaSvc --> KibanaAPI
+
+    PortainerSvc --> Pages
+    BackupSvc --> Pages
+    LlmSvc --> Pages
+    KibanaSvc --> Pages
+```
+
+## Ownership map
+
+| Area | Location | Responsibilities | Primary steward |
+| --- | --- | --- | --- |
+| UI pages | `app/Home.py`, `app/pages/`, `app/components/` | Streamlit views, layout, widget orchestration, sidebar navigation | UI maintainers |
+| Shared helpers | `app/dashboard_state.py`, `app/environment_cache.py`, `app/ui_helpers.py`, `app/utils/`, `app/config/`, `app/settings.py` | Centralised state management, caching, configuration resolution, generic utilities | Core maintainers |
+| Services | `app/services/` | Typed integration clients, background jobs, domain-specific logic reused by multiple pages | Integrations maintainers |
+
+> **Tip:** If you are unsure who owns a given area, tag the maintainers listed in `CODEOWNERS` (or repository admins) when opening a pull request.
+
+## Contributor guidelines
+
+### When to add a new page
+
+Create a new entry in `app/pages/` when:
+
+- Operators need a distinct workflow or navigation destination (it shows up as a new sidebar item).
+- The UI would otherwise become unwieldy (for example combining unrelated Portainer domains into one page).
+- You need to surface data sourced from a new integration and the experience warrants dedicated controls.
+
+Prefer extending an existing page when the feature builds on the same Portainer view, reuses the current filters, and can be explained alongside the existing charts or tables. Use `app/components/` for reusable UI fragments so other pages can stay consistent.
+
+### When to extend services or helpers
+
+- Put API integrations, scheduled tasks, and data shaping inside `app/services/`. Pages should not talk to HTTP endpoints or long-running jobs directly.
+- Add helper functions to `app/ui_helpers.py` or `app/utils/` only when they are UI-agnostic or reused by multiple Streamlit pages. Leave page-specific logic co-located with the page.
+- Keep shared state and caching logic in `app/dashboard_state.py` and `app/environment_cache.py`. If you need new flags or cached collections, extend those modules instead of duplicating state inside the pages.
+- Configuration knobs belong in `app/settings.py` or the appropriate `app/config/` module so they remain discoverable and testable.
+
+### Adding new services or integrations
+
+1. Model the client in `app/services/` with clear input/output types and docstrings.
+2. Update the module diagram above if the new service connects to additional upstream systems.
+3. Provide unit tests in `tests/` that exercise the new service in isolation.
+4. Expose the functionality through the relevant page using the shared state helpers.
+
+### Updating the diagram
+
+Whenever you introduce new cross-cutting modules, update the Mermaid diagram so the interaction map stays accurate. The README links here, so contributors rely on this page to understand the latest boundaries.
+
+## File naming conventions
+
+- Streamlit pages follow the numeric prefix format (`N_Title.py`) so the sidebar ordering remains deterministic.
+- Service modules use descriptive nouns (`kibana_client.py`, `backup_scheduler.py`), aligning with the functionality they encapsulate.
+- Helper modules avoid prefixes like `new_` or `temp_`; prefer descriptive names that explain their intent.
+
+Refer back to this document during reviews to ensure new code respects the boundaries between the UI, shared helpers, and services.


### PR DESCRIPTION
## Summary
- add a contributor-facing module boundaries guide with a Mermaid interaction diagram and ownership notes
- link the README to architecture documentation so newcomers can find the new guidance quickly
- introduce a CONTRIBUTING guide with a lightweight review checklist tied to the documented boundaries

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e58f35e5fc8333a7ee4a963c0774b0