### PR TITLE
Refactor Streamlit session orchestration into managers

### DIFF
--- a/app/managers/background_job_runner.py
+++ b/app/managers/background_job_runner.py
@@ -1,0 +1,28 @@
+"""Background orchestration helpers for Streamlit-agnostic usage."""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Iterable
+
+from ..services.backup_scheduler import maybe_run_scheduled_backups
+
+
+class BackgroundJobRunner:
+    """Encapsulate execution of background jobs with defensive guards."""
+
+    def __init__(
+        self,
+        *,
+        backup_runner: Callable[[Iterable[dict[str, object]]], None] = maybe_run_scheduled_backups,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._backup_runner = backup_runner
+        self._logger = logger or logging.getLogger(__name__)
+
+    def maybe_run_backups(self, environments: Iterable[dict[str, object]]) -> None:
+        """Execute the scheduled backup runner with defensive logging."""
+
+        try:
+            self._backup_runner(environments)
+        except Exception:  # pragma: no cover - protective guard
+            self._logger.warning("Scheduled backup execution failed", exc_info=True)

--- a/app/managers/environment_manager.py
+++ b/app/managers/environment_manager.py
@@ -1,0 +1,123 @@
+"""Session-agnostic helpers for managing Portainer environments."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, MutableMapping
+
+from ..settings import PortainerEnvironment, get_configured_environments, load_environments, save_environments
+
+StateMapping = MutableMapping[str, object]
+EnvironmentList = list[dict[str, object]]
+
+
+def _default_clear_cache(*, persistent: bool = True) -> None:  # pragma: no cover - placeholder
+    """Fallback cache clearer used when none is provided."""
+
+
+@dataclass
+class EnvironmentManager:
+    """Coordinate persisted environments independently of Streamlit."""
+
+    state: StateMapping
+    clear_cache: Callable[..., None] = field(default=_default_clear_cache)
+    loader: Callable[[], EnvironmentList] = field(default=load_environments)
+    saver: Callable[[Iterable[dict[str, object]]], None] = field(default=save_environments)
+    env_setter: Callable[[str, str], None] = field(default=os.environ.__setitem__)
+
+    ENVIRONMENTS_KEY: str = "portainer_envs"
+    SELECTED_ENV_KEY: str = "portainer_selected_env"
+    APPLIED_ENV_KEY: str = "portainer_active_env_applied"
+
+    def initialise(self) -> EnvironmentList:
+        """Ensure environments and the active selection are initialised."""
+
+        environments = self.ensure_environments_loaded()
+        self.ensure_selection(environments)
+        return environments
+
+    def ensure_environments_loaded(self) -> EnvironmentList:
+        """Load environments into the state mapping when missing."""
+
+        if self.ENVIRONMENTS_KEY not in self.state:
+            self.state[self.ENVIRONMENTS_KEY] = list(self.loader())
+        value = self.state.get(self.ENVIRONMENTS_KEY, [])
+        if not isinstance(value, list):
+            value = list(value)
+            self.state[self.ENVIRONMENTS_KEY] = value
+        return list(value)
+
+    def ensure_selection(self, environments: EnvironmentList | None = None) -> None:
+        """Guarantee a default selection is available for downstream code."""
+
+        if environments is None:
+            environments = self.ensure_environments_loaded()
+        if self.SELECTED_ENV_KEY in self.state:
+            return
+        if environments:
+            default = str(environments[0].get("name", ""))
+        else:
+            default = ""
+        self.state[self.SELECTED_ENV_KEY] = default
+
+    def get_saved_environments(self) -> EnvironmentList:
+        """Return a serialisable snapshot of the configured environments."""
+
+        return list(self.ensure_environments_loaded())
+
+    def set_saved_environments(self, environments: Iterable[dict[str, object]]) -> None:
+        """Persist the provided environments to the session and disk."""
+
+        serialisable = list(environments)
+        self.state[self.ENVIRONMENTS_KEY] = serialisable
+        self.saver(serialisable)
+
+    def get_selected_environment_name(self) -> str:
+        """Return the name of the currently selected environment."""
+
+        selection = self.state.get(self.SELECTED_ENV_KEY, "")
+        return str(selection)
+
+    def set_active_environment(self, name: str) -> None:
+        """Update the active environment selection and clear caches."""
+
+        previous_selection = str(self.state.get(self.SELECTED_ENV_KEY, ""))
+        self.state[self.SELECTED_ENV_KEY] = name
+        self.state.pop(self.APPLIED_ENV_KEY, None)
+        persistent = bool(previous_selection.strip())
+        self.clear_cache(persistent=persistent)
+
+    def apply_selected_environment(self) -> None:
+        """Apply the selected environment and mark it as active."""
+
+        selected = self.get_selected_environment_name()
+        applied = self.state.get(self.APPLIED_ENV_KEY)
+        if applied == selected:
+            return
+        environment = self._get_selected_environment()
+        if environment is None:
+            return
+        self._set_environment_variables(environment)
+        self.state[self.APPLIED_ENV_KEY] = selected
+
+    def _get_selected_environment(self) -> dict[str, object] | None:
+        selected_name = self.get_selected_environment_name()
+        for environment in self.get_saved_environments():
+            if environment.get("name") == selected_name:
+                return environment
+        return None
+
+    def _set_environment_variables(self, environment: dict[str, object]) -> None:
+        self.env_setter("PORTAINER_API_URL", str(environment.get("api_url", "")))
+        self.env_setter("PORTAINER_API_KEY", str(environment.get("api_key", "")))
+        verify_ssl = bool(environment.get("verify_ssl", True))
+        self.env_setter("PORTAINER_VERIFY_SSL", "true" if verify_ssl else "false")
+        name = environment.get("name")
+        if name:
+            self.env_setter("PORTAINER_ENVIRONMENT_NAME", str(name))
+
+    @staticmethod
+    def load_configured_environment_settings() -> tuple[PortainerEnvironment, ...]:
+        """Expose the environment configuration loader for convenience."""
+
+        return tuple(get_configured_environments())

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -13,12 +13,16 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
@@ -35,12 +39,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -61,8 +69,10 @@ render_page_header(
     ),
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings()

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -20,12 +20,16 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
@@ -38,12 +42,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -67,8 +75,10 @@ render_page_header(
     ),
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings()

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -19,12 +19,16 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
@@ -37,12 +41,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -61,8 +69,10 @@ render_page_header(
     description="Inspect active containers, their images and exposed ports.",
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings()

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -23,12 +23,16 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import (  # type: ignore[import-not-found]
         PortainerAPIError,
@@ -44,12 +48,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import (  # type: ignore[no-redef]
         PortainerAPIError,
@@ -303,8 +311,10 @@ render_page_header(
     description="Identify the images powering your workloads and where they are deployed.",
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings()

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -19,25 +19,25 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
-        apply_selected_environment,
         clear_cached_data,
-        get_saved_environments,
-        get_selected_environment_name,
-        initialise_session_state,
-        set_active_environment,
-        set_saved_environments,
         trigger_rerun,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
     from dashboard_state import (  # type: ignore[no-redef]
-        apply_selected_environment,
         clear_cached_data,
-        get_saved_environments,
-        get_selected_environment_name,
-        initialise_session_state,
-        set_active_environment,
-        set_saved_environments,
         trigger_rerun,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
 
 try:  # pragma: no cover - import shim for Streamlit runtime
@@ -131,17 +131,19 @@ render_logout_button()
 
 st.title("Settings")
 
-initialise_session_state()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
 
 pending_active_env_key = "portainer_env_pending_active"
 if pending_active := st.session_state.pop(pending_active_env_key, None):
-    set_active_environment(pending_active)
+    environment_manager.set_active_environment(pending_active)
 
-apply_selected_environment()
+environment_manager.apply_selected_environment()
 
 st.header("Portainer environments")
 
-environments_state = get_saved_environments()
+environments_state = environment_manager.get_saved_environments()
 env_names = [env.get("name", "") for env in environments_state if env.get("name")]
 
 form_selection_key = "portainer_env_form_selection"
@@ -153,7 +155,7 @@ if pending_selection := st.session_state.pop(pending_selection_key, None):
     st.session_state[form_selection_key] = pending_selection
 
 if st.session_state.get(form_selection_key) not in options:
-    default_env = get_selected_environment_name() or "New environment"
+    default_env = environment_manager.get_selected_environment_name() or "New environment"
     st.session_state[form_selection_key] = (
         default_env if default_env in env_names else "New environment"
     )
@@ -263,8 +265,8 @@ if submitted:
             updated_envs.append(updated_env)
         else:
             updated_envs[edit_index] = updated_env
-        set_saved_environments(updated_envs)
-        set_active_environment(name_value)
+        environment_manager.set_saved_environments(updated_envs)
+        environment_manager.set_active_environment(name_value)
         st.session_state[pending_selection_key] = name_value
         st.session_state[prev_selection_key] = name_value
         clear_cached_data()
@@ -293,7 +295,7 @@ if test_connection_clicked and not submitted:
 
 if env_names:
     st.subheader("Active environment")
-    active_env = get_selected_environment_name()
+    active_env = environment_manager.get_selected_environment_name()
     choice = st.radio(
         "Choose which environment to use for dashboards",
         env_names,
@@ -301,7 +303,7 @@ if env_names:
         key="portainer_selected_env",
     )
     if choice != active_env:
-        set_active_environment(choice)
+        environment_manager.set_active_environment(choice)
         rerun_app()
 
 else:
@@ -490,8 +492,8 @@ for env in environments_state:
             updated_envs = [
                 existing for existing in environments_state if existing.get("name") != env_name
             ]
-            set_saved_environments(updated_envs)
-            if get_selected_environment_name() == env_name:
+            environment_manager.set_saved_environments(updated_envs)
+            if environment_manager.get_selected_environment_name() == env_name:
                 next_name = updated_envs[0]["name"] if updated_envs else ""
                 st.session_state[pending_active_env_key] = next_name
             clear_cached_data()

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -18,12 +18,16 @@ try:  # pragma: no cover - runtime imports resolved differently during tests
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.services.llm_client import (  # type: ignore[import-not-found]
@@ -46,12 +50,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from services.llm_client import LLMClient, LLMClientError  # type: ignore[no-redef]
@@ -317,8 +325,10 @@ render_page_header(
     ),
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 conversation: list[AssistantTurn] = st.session_state.setdefault("llm_assistant_turns", [])
 

--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -14,12 +14,16 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
+        BackgroundJobRunner,
+    )
+    from app.managers.environment_manager import (  # type: ignore[import-not-found]
+        EnvironmentManager,
     )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.services.kibana_client import (  # type: ignore[import-not-found]
@@ -38,12 +42,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
-        apply_selected_environment,
-        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
+    )
+    from managers.background_job_runner import (  # type: ignore[no-redef]
+        BackgroundJobRunner,
+    )
+    from managers.environment_manager import (  # type: ignore[no-redef]
+        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from services.kibana_client import (  # type: ignore[no-redef]
@@ -94,8 +102,10 @@ render_page_header(
     ),
 )
 
-initialise_session_state()
-apply_selected_environment()
+environment_manager = EnvironmentManager(st.session_state)
+environments = environment_manager.initialise()
+BackgroundJobRunner().maybe_run_backups(environments)
+environment_manager.apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings()

--- a/tests/managers/test_background_job_runner.py
+++ b/tests/managers/test_background_job_runner.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.managers.background_job_runner import BackgroundJobRunner
+
+
+def test_maybe_run_backups_invokes_runner():
+    calls: list[list[dict[str, Any]]] = []
+
+    def fake_runner(environments):
+        calls.append(list(environments))
+
+    runner = BackgroundJobRunner(backup_runner=fake_runner)
+    payload = [{"name": "Prod"}]
+
+    runner.maybe_run_backups(payload)
+
+    assert calls == [payload]
+
+
+def test_maybe_run_backups_logs_exception(caplog):
+    def failing_runner(environments):  # pragma: no cover - exercised via logging assertion
+        raise RuntimeError("boom")
+
+    runner = BackgroundJobRunner(backup_runner=failing_runner)
+
+    with caplog.at_level("WARNING"):
+        runner.maybe_run_backups([{"name": "Prod"}])
+
+    assert any("Scheduled backup execution failed" in record.message for record in caplog.records)

--- a/tests/managers/test_environment_manager.py
+++ b/tests/managers/test_environment_manager.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.managers.environment_manager import EnvironmentManager
+
+
+def test_initialise_loads_environments_and_sets_default_selection():
+    state: dict[str, Any] = {}
+    loader_called = False
+
+    def fake_loader() -> list[dict[str, object]]:
+        nonlocal loader_called
+        loader_called = True
+        return [
+            {
+                "name": "Prod",
+                "api_url": "https://prod.example/api",
+                "api_key": "token",
+                "verify_ssl": True,
+            }
+        ]
+
+    manager = EnvironmentManager(
+        state,
+        clear_cache=lambda **_: None,
+        loader=fake_loader,
+        saver=lambda environments: None,
+        env_setter=lambda key, value: None,
+    )
+
+    environments = manager.initialise()
+
+    assert loader_called is True
+    assert environments[0]["name"] == "Prod"
+    assert state[EnvironmentManager.ENVIRONMENTS_KEY][0]["name"] == "Prod"
+    assert state[EnvironmentManager.SELECTED_ENV_KEY] == "Prod"
+
+
+def test_initialise_preserves_existing_selection():
+    state: dict[str, Any] = {
+        EnvironmentManager.ENVIRONMENTS_KEY: [
+            {"name": "Prod"},
+            {"name": "Staging"},
+        ],
+        EnvironmentManager.SELECTED_ENV_KEY: "Staging",
+    }
+
+    manager = EnvironmentManager(
+        state,
+        clear_cache=lambda **_: None,
+        loader=lambda: state[EnvironmentManager.ENVIRONMENTS_KEY],
+        saver=lambda environments: None,
+        env_setter=lambda key, value: None,
+    )
+
+    manager.initialise()
+
+    assert state[EnvironmentManager.SELECTED_ENV_KEY] == "Staging"
+
+
+def test_set_saved_environments_persists_to_state_and_disk():
+    state: dict[str, Any] = {}
+    saved_payload: list[list[dict[str, object]]] = []
+
+    def fake_saver(environments: list[dict[str, object]]) -> None:
+        saved_payload.append(list(environments))
+
+    manager = EnvironmentManager(
+        state,
+        clear_cache=lambda **_: None,
+        loader=lambda: [],
+        saver=fake_saver,
+        env_setter=lambda key, value: None,
+    )
+
+    payload = [
+        {
+            "name": "Prod",
+            "api_url": "https://prod.example/api",
+            "api_key": "token",
+            "verify_ssl": False,
+        }
+    ]
+
+    manager.set_saved_environments(payload)
+
+    assert state[EnvironmentManager.ENVIRONMENTS_KEY] == payload
+    assert saved_payload == [payload]
+
+
+@pytest.mark.parametrize(
+    "previous,expected_persistent",
+    [("", False), ("   ", False), ("Prod", True)],
+)
+def test_set_active_environment_flags_cache_invalidation(previous: str, expected_persistent: bool):
+    state: dict[str, Any] = {
+        EnvironmentManager.ENVIRONMENTS_KEY: [
+            {"name": "Prod"},
+            {"name": "Staging"},
+        ],
+        EnvironmentManager.SELECTED_ENV_KEY: previous,
+    }
+
+    cache_flags: list[bool] = []
+
+    def fake_clear_cache(*, persistent: bool) -> None:
+        cache_flags.append(persistent)
+
+    manager = EnvironmentManager(
+        state,
+        clear_cache=fake_clear_cache,
+        loader=lambda: state[EnvironmentManager.ENVIRONMENTS_KEY],
+        saver=lambda environments: None,
+        env_setter=lambda key, value: None,
+    )
+
+    manager.set_active_environment("Staging")
+
+    assert state[EnvironmentManager.SELECTED_ENV_KEY] == "Staging"
+    assert state.get(EnvironmentManager.APPLIED_ENV_KEY) is None
+    assert cache_flags == [expected_persistent]
+
+
+def test_apply_selected_environment_sets_environment_variables():
+    state: dict[str, Any] = {
+        EnvironmentManager.ENVIRONMENTS_KEY: [
+            {
+                "name": "Prod",
+                "api_url": "https://prod.example/api",
+                "api_key": "token",
+                "verify_ssl": False,
+            }
+        ],
+        EnvironmentManager.SELECTED_ENV_KEY: "Prod",
+    }
+
+    assigned: dict[str, str] = {}
+    call_count = 0
+
+    def fake_env_setter(key: str, value: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        assigned[key] = value
+
+    manager = EnvironmentManager(
+        state,
+        clear_cache=lambda **_: None,
+        loader=lambda: state[EnvironmentManager.ENVIRONMENTS_KEY],
+        saver=lambda environments: None,
+        env_setter=fake_env_setter,
+    )
+
+    manager.apply_selected_environment()
+    manager.apply_selected_environment()  # second call should be a no-op
+
+    assert assigned == {
+        "PORTAINER_API_URL": "https://prod.example/api",
+        "PORTAINER_API_KEY": "token",
+        "PORTAINER_VERIFY_SSL": "false",
+        "PORTAINER_ENVIRONMENT_NAME": "Prod",
+    }
+    assert state[EnvironmentManager.APPLIED_ENV_KEY] == "Prod"
+    assert call_count == 4  # second call should not reapply


### PR DESCRIPTION
## Summary
- add EnvironmentManager and BackgroundJobRunner modules to coordinate session state and scheduled backups outside Streamlit helpers
- update dashboard pages to rely on the new managers instead of manipulating session keys directly
- add targeted unit tests that exercise the new orchestration helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e58eb857a083339e99ef9e607a59b5