### PR TITLE
Update environment cache tests for CacheConfig signature

### DIFF
--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime as _dt
+from functools import partial
 from pathlib import Path
 
 import streamlit as st
@@ -30,7 +31,11 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
+        apply_selected_environment,
         clear_cached_data,
+        initialise_session_state,
+        set_active_environment,
+        set_saved_environments,
         trigger_rerun,
     )
     from app.managers.background_job_runner import (  # type: ignore[import-not-found]
@@ -41,7 +46,11 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     )
 except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a script
     from dashboard_state import (  # type: ignore[no-redef]
+        apply_selected_environment,
         clear_cached_data,
+        initialise_session_state,
+        set_active_environment,
+        set_saved_environments,
         trigger_rerun,
     )
     from managers.background_job_runner import (  # type: ignore[no-redef]
@@ -155,7 +164,8 @@ if pending_active := st.session_state.pop(pending_active_env_key, None):
 
 apply_selected_environment(CONFIG)
 environment_manager = EnvironmentManager(
-    st.session_state, clear_cache=clear_cached_data
+    st.session_state,
+    clear_cache=partial(clear_cached_data, CONFIG),
 )
 environments = environment_manager.initialise()
 BackgroundJobRunner().maybe_run_backups(environments)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,15 @@
+"""Pytest configuration for the dashboard test-suite."""
+
 from __future__ import annotations
 
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
-
 
 if importlib.util.find_spec("jwt") is None:
     stub_path = Path(__file__).with_name("_jwt_stub.py")
@@ -18,17 +20,10 @@ if importlib.util.find_spec("jwt") is None:
     sys.modules["jwt"] = module
     spec.loader.exec_module(module)
 
-"""Pytest configuration for the dashboard test-suite."""
-from __future__ import annotations
-
-import sys
-
 try:  # pragma: no cover - exercised indirectly when dependency is present
     import jwt  # type: ignore  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover - depends on environment
     from importlib.util import module_from_spec, spec_from_file_location
-    from pathlib import Path
-    from types import ModuleType
 
     stub_path = Path(__file__).with_name("_jwt_stub.py")
     spec = spec_from_file_location("_jwt_stub", stub_path)

--- a/tests/test_environment_cache.py
+++ b/tests/test_environment_cache.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from app.config import CacheConfig
 from app import environment_cache
 
 
@@ -16,19 +17,20 @@ def test_store_cache_entry_is_atomic_under_concurrency(tmp_path, monkeypatch):
     monkeypatch.setenv("PORTAINER_CACHE_DIR", str(tmp_path))
 
     key = "concurrent-key"
+    config = CacheConfig(enabled=True, ttl_seconds=900, directory=tmp_path)
     writers = 5
     barrier = threading.Barrier(writers)
 
     def _write_payload(index: int) -> None:
         barrier.wait()
-        environment_cache.store_cache_entry(key, {"value": index})
+        environment_cache.store_cache_entry(config, key, {"value": index})
 
     with ThreadPoolExecutor(max_workers=writers) as executor:
         futures = [executor.submit(_write_payload, i) for i in range(writers)]
         for future in futures:
             future.result(timeout=2)
 
-    entry = environment_cache.load_cache_entry(key)
+    entry = environment_cache.load_cache_entry(config, key)
     assert entry is not None
     assert entry.payload["value"] in set(range(writers))
 
@@ -41,6 +43,7 @@ def test_cache_read_waits_until_write_completes(tmp_path, monkeypatch):
     monkeypatch.setenv("PORTAINER_CACHE_DIR", str(tmp_path))
 
     key = "slow-key"
+    config = CacheConfig(enabled=True, ttl_seconds=900, directory=tmp_path)
     partial_written = threading.Event()
     allow_completion = threading.Event()
 
@@ -58,9 +61,11 @@ def test_cache_read_waits_until_write_completes(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "write_text", _slow_write)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        writer = executor.submit(environment_cache.store_cache_entry, key, {"value": "payload"})
+        writer = executor.submit(
+            environment_cache.store_cache_entry, config, key, {"value": "payload"}
+        )
         assert partial_written.wait(timeout=1)
-        reader = executor.submit(environment_cache.load_cache_entry, key)
+        reader = executor.submit(environment_cache.load_cache_entry, config, key)
         time.sleep(0.1)
         assert not reader.done()
         allow_completion.set()


### PR DESCRIPTION
## Summary
- update the environment cache tests to construct a CacheConfig and pass it to store/load helpers
- ensure the concurrency helpers continue to run against the configured cache directory

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e59b1fbeac8333a37733ea67a939b3