### PR TITLE
Restore environment cache API compatibility

### DIFF
--- a/app/environment_cache.py
+++ b/app/environment_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,7 +16,14 @@ try:  # pragma: no cover - import shim for Streamlit runtime
 except (ModuleNotFoundError, ImportError):  # pragma: no cover - fallback when executed as a script
     from file_locking import FileLock, Timeout  # type: ignore[no-redef]
 
-from .config import CacheConfig
+from .config import (
+    CACHE_DIR_ENV_VAR,
+    CACHE_ENABLED_ENV_VAR,
+    CACHE_TTL_ENV_VAR,
+    CacheConfig,
+    get_config,
+    reload_config,
+)
 
 try:  # pragma: no cover - import shim for Streamlit runtime
     from .settings import PortainerEnvironment  # type: ignore[import-not-found]
@@ -28,6 +36,7 @@ _CACHE_LOCK_SUFFIX = ".lock"
 _CACHE_KEY_DERIVATION_SALT = b"portainer-environment-cache"
 _CACHE_KEY_DERIVATION_ROUNDS = 200_000
 _CACHE_LOCK_TIMEOUT_SECONDS = 5.0
+_CACHE_ENV_SIGNATURE: tuple[str | None, str | None, str | None] | None = None
 
 
 __all__ = [
@@ -56,23 +65,47 @@ class CacheEntry:
         if self.expires_at is None:
             return False
         return self.expires_at <= time.time()
-def is_cache_enabled(config: CacheConfig) -> bool:
+
+
+def _current_cache_env_signature() -> tuple[str | None, str | None, str | None]:
+    return (
+        os.getenv(CACHE_ENABLED_ENV_VAR),
+        os.getenv(CACHE_TTL_ENV_VAR),
+        os.getenv(CACHE_DIR_ENV_VAR),
+    )
+
+
+def _resolve_cache_config(config: CacheConfig | None = None) -> CacheConfig:
+    """Return a cache configuration, defaulting to the global settings."""
+
+    if config is not None:
+        return config
+
+    global _CACHE_ENV_SIGNATURE
+    signature = _current_cache_env_signature()
+    if signature != _CACHE_ENV_SIGNATURE:
+        _CACHE_ENV_SIGNATURE = signature
+        return reload_config().cache
+    return get_config().cache
+
+
+def is_cache_enabled(config: CacheConfig | None = None) -> bool:
     """Return ``True`` when persistent caching is enabled."""
 
-    return config.enabled
+    return _resolve_cache_config(config).enabled
 
 
-def cache_ttl_seconds(config: CacheConfig) -> int:
+def cache_ttl_seconds(config: CacheConfig | None = None) -> int:
     """Return the configured cache TTL in seconds."""
 
-    return config.ttl_seconds
+    return _resolve_cache_config(config).ttl_seconds
 
 
-def _cache_directory(config: CacheConfig) -> Path:
-    return config.directory
+def _cache_directory(config: CacheConfig | None = None) -> Path:
+    return _resolve_cache_config(config).directory
 
 
-def _cache_path(config: CacheConfig, key: str) -> Path:
+def _cache_path(config: CacheConfig | None, key: str) -> Path:
     safe_key = f"{key}{_CACHE_FILE_SUFFIX}"
     return _cache_directory(config) / safe_key
 
@@ -102,9 +135,7 @@ def _acquire_cache_lock(path: Path) -> Iterator[None]:
                 LOGGER.debug("Cache lock already released for %s", path)
 
 
-def _ensure_cache_directory() -> Path:
-    directory = _cache_directory()
-def _ensure_cache_directory(config: CacheConfig) -> Path:
+def _ensure_cache_directory(config: CacheConfig | None = None) -> Path:
     directory = _cache_directory(config)
     try:
         directory.mkdir(parents=True, exist_ok=True)
@@ -176,9 +207,7 @@ def _read_payload(path: Path) -> CacheEntry | None:
     return CacheEntry(payload=payload, refreshed_at=refreshed_at, expires_at=expires_at)
 
 
-def load_cache_entry(config: CacheConfig, key: str) -> CacheEntry | None:
-    """Load a cached payload for ``key`` when available."""
-
+def _load_cache_entry(config: CacheConfig, key: str) -> CacheEntry | None:
     if not is_cache_enabled(config):
         return None
     path = _cache_path(config, key)
@@ -195,9 +224,40 @@ def load_cache_entry(config: CacheConfig, key: str) -> CacheEntry | None:
         return None
 
 
-def store_cache_entry(
-    config: CacheConfig, key: str, payload: dict[str, Any]
-) -> float | None:
+def load_cache_entry(*args: Any, **kwargs: Any) -> CacheEntry | None:
+    """Load a cached payload for ``key`` when available.
+
+    This helper accepts both the legacy ``load_cache_entry(key)`` signature and
+    the newer ``load_cache_entry(config, key)`` form. The optional ``config``
+    keyword argument takes precedence when provided.
+    """
+
+    config: CacheConfig | None
+    key: str
+
+    if "config" in kwargs:
+        config = kwargs.pop("config")
+        if kwargs:
+            raise TypeError("Unexpected keyword arguments: " + ", ".join(kwargs))
+        if len(args) != 1:
+            raise TypeError("load_cache_entry() missing required key argument")
+        key = args[0]
+    elif len(args) == 2:
+        config, key = args  # type: ignore[assignment]
+    elif len(args) == 1:
+        (key,) = args
+        config = None
+    else:
+        raise TypeError("load_cache_entry() accepts either (key) or (config, key)")
+
+    if not isinstance(key, str):
+        raise TypeError("load_cache_entry() requires key to be a string")
+
+    resolved = _resolve_cache_config(config)
+    return _load_cache_entry(resolved, key)
+
+
+def store_cache_entry(*args: Any, **kwargs: Any) -> float | None:
     """Persist ``payload`` under ``key`` respecting the configured TTL.
 
     Returns
@@ -207,13 +267,37 @@ def store_cache_entry(
         ``None`` when caching is disabled or persistence fails.
     """
 
-    if not is_cache_enabled(config):
+    if "config" in kwargs:
+        config = kwargs.pop("config")
+        if kwargs:
+            raise TypeError("Unexpected keyword arguments: " + ", ".join(kwargs))
+        if len(args) != 2:
+            raise TypeError("store_cache_entry() missing required key/payload arguments")
+        key, payload = args
+    elif len(args) == 3:
+        config, key, payload = args  # type: ignore[assignment]
+    elif len(args) == 2:
+        config = None
+        key, payload = args
+    else:
+        raise TypeError(
+            "store_cache_entry() accepts either (key, payload) or (config, key, payload)"
+        )
+
+    if not isinstance(key, str):
+        raise TypeError("store_cache_entry() requires key to be a string")
+    if not isinstance(payload, dict):
+        raise TypeError("store_cache_entry() requires payload to be a dictionary")
+
+    resolved = _resolve_cache_config(config)
+
+    if not is_cache_enabled(resolved):
         return None
     try:
-        _ensure_cache_directory(config)
+        _ensure_cache_directory(resolved)
     except OSError:
         return None
-    ttl = cache_ttl_seconds(config)
+    ttl = cache_ttl_seconds(resolved)
     expires_at: float | None
     if ttl <= 0:
         expires_at = None
@@ -225,7 +309,7 @@ def store_cache_entry(
         "refreshed_at": refreshed_at,
         "payload": payload,
     }
-    path = _cache_path(config, key)
+    path = _cache_path(resolved, key)
     try:
         with _acquire_cache_lock(path):
             path.write_text(json.dumps(data), "utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,46 +1,38 @@
 from __future__ import annotations
 
+"""Pytest configuration for the dashboard test-suite."""
+
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
-if importlib.util.find_spec("jwt") is None:
+def _load_jwt_stub() -> ModuleType:
+    """Load the lightweight JWT stub used during tests.
+
+    The production dependency is optional, so when it is not installed we load
+    a local shim that exposes the minimal surface required by the test suite.
+    """
+
     stub_path = Path(__file__).with_name("_jwt_stub.py")
     spec = importlib.util.spec_from_file_location("jwt", stub_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError("Unable to load JWT stub for tests")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["jwt"] = module
-    spec.loader.exec_module(module)
-
-"""Pytest configuration for the dashboard test-suite."""
-from __future__ import annotations
-
-import sys
-
-try:  # pragma: no cover - exercised indirectly when dependency is present
-    import jwt  # type: ignore  # noqa: F401
-except ModuleNotFoundError:  # pragma: no cover - depends on environment
-    from importlib.util import module_from_spec, spec_from_file_location
-    from pathlib import Path
-    from types import ModuleType
-
-    stub_path = Path(__file__).with_name("_jwt_stub.py")
-    spec = spec_from_file_location("_jwt_stub", stub_path)
     if spec is None or spec.loader is None:  # pragma: no cover - defensive
-        raise
-    module = module_from_spec(spec)
-    sys.modules.setdefault("_jwt_stub", module)
-    spec.loader.exec_module(module)  # type: ignore[arg-type]
+        raise RuntimeError("Unable to load JWT stub for tests")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
 
     module.__name__ = "jwt"
     module.__package__ = "jwt"
+    return module
 
-    jwt_module: ModuleType = module
+
+if importlib.util.find_spec("jwt") is None:  # pragma: no cover - depends on env
+    jwt_module = _load_jwt_stub()
     sys.modules.setdefault("jwt", jwt_module)
     sys.modules.setdefault("jwt.algorithms", jwt_module)


### PR DESCRIPTION
## Summary
- fix the pytest configuration to load the JWT stub without duplicate future imports
- restore backwards compatibility for environment cache helpers while keeping the new config-aware path
- add automatic cache config reloading when environment variables change so concurrent tests remain stable

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e59d29e4c08333a3cfe7db3fb3d1bb