### PR TITLE
Fix missing session initialisation imports on dashboard pages

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -16,6 +16,10 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         require_authentication,
         get_active_session_count,
     )
+    from app.dashboard_state import (  # type: ignore[import-not-found]
+        apply_selected_environment,
+        initialise_session_state,
+    )
     from app.managers.background_job_runner import (  # type: ignore[import-not-found]
         BackgroundJobRunner,
     )
@@ -31,6 +35,10 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         render_logout_button,
         require_authentication,
         get_active_session_count,
+    )
+    from dashboard_state import (  # type: ignore[no-redef]
+        apply_selected_environment,
+        initialise_session_state,
     )
     from managers.background_job_runner import (  # type: ignore[no-redef]
         BackgroundJobRunner,

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -17,6 +17,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -47,6 +49,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -31,6 +31,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -53,6 +55,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -30,6 +30,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -52,6 +54,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -34,6 +34,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -59,6 +61,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -29,6 +29,8 @@ try:  # pragma: no cover - runtime imports resolved differently during tests
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -61,6 +63,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,

--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -25,6 +25,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
     from app.dashboard_state import (  # type: ignore[import-not-found]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,
@@ -53,6 +55,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         ConfigurationError,
         NoEnvironmentsConfiguredError,
+        apply_selected_environment,
+        initialise_session_state,
         load_configured_environment_settings,
         load_portainer_data,
         render_data_refresh_notice,


### PR DESCRIPTION
## Summary
- import `initialise_session_state` and `apply_selected_environment` in the Home page and dashboard views
- ensure both package and script execution paths expose the session helpers to prevent NameError during login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e600d49590833386ed42b8c34fe632