### PR TITLE
Fix session initialisation API regression

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -20,9 +20,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         apply_selected_environment,
         initialise_session_state,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
     from app.managers.environment_manager import (  # type: ignore[import-not-found]
         EnvironmentManager,
     )
@@ -39,9 +36,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
     from dashboard_state import (  # type: ignore[no-redef]
         apply_selected_environment,
         initialise_session_state,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
     )
     from managers.environment_manager import (  # type: ignore[no-redef]
         EnvironmentManager,
@@ -61,12 +55,9 @@ except ConfigurationError as exc:
 require_authentication(CONFIG)
 render_logout_button()
 
-initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
 environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+initialise_session_state(CONFIG, environment_manager=environment_manager)
+apply_selected_environment(environment_manager=environment_manager)
 
 st.markdown(
     """

--- a/app/pages/1_Fleet_Overview.py
+++ b/app/pages/1_Fleet_Overview.py
@@ -24,12 +24,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
         ExportableDataFrame,
@@ -55,12 +49,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -88,11 +76,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings(CONFIG)

--- a/app/pages/3_Container_Health.py
+++ b/app/pages/3_Container_Health.py
@@ -38,12 +38,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
         ExportableDataFrame,
@@ -61,12 +55,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -97,11 +85,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings(CONFIG)

--- a/app/pages/4_Workload_Explorer.py
+++ b/app/pages/4_Workload_Explorer.py
@@ -37,12 +37,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.ui_helpers import (  # type: ignore[import-not-found]
         ExportableDataFrame,
@@ -60,12 +54,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from ui_helpers import (  # type: ignore[no-redef]
@@ -90,11 +78,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings(CONFIG)

--- a/app/pages/5_Image_Footprint.py
+++ b/app/pages/5_Image_Footprint.py
@@ -41,12 +41,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import (  # type: ignore[import-not-found]
         PortainerAPIError,
         PortainerClient,
@@ -67,12 +61,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import (  # type: ignore[no-redef]
         PortainerAPIError,
@@ -333,11 +321,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings(CONFIG)

--- a/app/pages/6_Settings.py
+++ b/app/pages/6_Settings.py
@@ -34,12 +34,8 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         apply_selected_environment,
         clear_cached_data,
         initialise_session_state,
-        set_active_environment,
         set_saved_environments,
         trigger_rerun,
-    )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
     )
     from app.managers.environment_manager import (  # type: ignore[import-not-found]
         EnvironmentManager,
@@ -49,12 +45,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         apply_selected_environment,
         clear_cached_data,
         initialise_session_state,
-        set_active_environment,
         set_saved_environments,
         trigger_rerun,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
     )
     from managers.environment_manager import (  # type: ignore[no-redef]
         EnvironmentManager,
@@ -156,25 +148,18 @@ render_logout_button()
 
 st.title("Settings")
 
-initialise_session_state(CONFIG)
-
-pending_active_env_key = "portainer_env_pending_active"
-if pending_active := st.session_state.pop(pending_active_env_key, None):
-    set_active_environment(CONFIG, pending_active)
-
-apply_selected_environment(CONFIG)
 environment_manager = EnvironmentManager(
     st.session_state,
     clear_cache=partial(clear_cached_data, CONFIG),
 )
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
+
+initialise_session_state(CONFIG, environment_manager=environment_manager)
 
 pending_active_env_key = "portainer_env_pending_active"
 if pending_active := st.session_state.pop(pending_active_env_key, None):
     environment_manager.set_active_environment(pending_active)
 
-environment_manager.apply_selected_environment()
+apply_selected_environment(environment_manager=environment_manager)
 
 st.header("Portainer environments")
 
@@ -301,7 +286,6 @@ if submitted:
         else:
             updated_envs[edit_index] = updated_env
         set_saved_environments(updated_envs)
-        set_active_environment(CONFIG, name_value)
         environment_manager.set_saved_environments(updated_envs)
         environment_manager.set_active_environment(name_value)
         st.session_state[pending_selection_key] = name_value
@@ -340,7 +324,6 @@ if env_names:
         key="portainer_selected_env",
     )
     if choice != active_env:
-        set_active_environment(CONFIG, choice)
         environment_manager.set_active_environment(choice)
         rerun_app()
 

--- a/app/pages/7_LLM_Assistant.py
+++ b/app/pages/7_LLM_Assistant.py
@@ -36,12 +36,6 @@ try:  # pragma: no cover - runtime imports resolved differently during tests
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.services.llm_client import (  # type: ignore[import-not-found]
         LLMClient,
@@ -69,12 +63,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from services.llm_client import LLMClient, LLMClientError  # type: ignore[no-redef]
@@ -347,11 +335,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 conversation: list[AssistantTurn] = st.session_state.setdefault("llm_assistant_turns", [])
 

--- a/app/pages/8_Edge_Agent_Logs.py
+++ b/app/pages/8_Edge_Agent_Logs.py
@@ -32,12 +32,6 @@ try:  # pragma: no cover - import shim for Streamlit runtime
         render_data_refresh_notice,
         render_sidebar_filters,
     )
-    from app.managers.background_job_runner import (  # type: ignore[import-not-found]
-        BackgroundJobRunner,
-    )
-    from app.managers.environment_manager import (  # type: ignore[import-not-found]
-        EnvironmentManager,
-    )
     from app.portainer_client import PortainerAPIError  # type: ignore[import-not-found]
     from app.services.kibana_client import (  # type: ignore[import-not-found]
         KibanaClientError,
@@ -61,12 +55,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when executed as a sc
         load_portainer_data,
         render_data_refresh_notice,
         render_sidebar_filters,
-    )
-    from managers.background_job_runner import (  # type: ignore[no-redef]
-        BackgroundJobRunner,
-    )
-    from managers.environment_manager import (  # type: ignore[no-redef]
-        EnvironmentManager,
     )
     from portainer_client import PortainerAPIError  # type: ignore[no-redef]
     from services.kibana_client import (  # type: ignore[no-redef]
@@ -124,11 +112,7 @@ render_page_header(
 )
 
 initialise_session_state(CONFIG)
-apply_selected_environment(CONFIG)
-environment_manager = EnvironmentManager(st.session_state)
-environments = environment_manager.initialise()
-BackgroundJobRunner().maybe_run_backups(environments)
-environment_manager.apply_selected_environment()
+apply_selected_environment()
 
 try:
     configured_environments = load_configured_environment_settings(CONFIG)


### PR DESCRIPTION
## Summary
- restore the shared session initialiser so it seeds default environments and runs background jobs with optional config support
- update the Home and dashboard pages to rely on the helper instead of re-running background jobs manually
- streamline the settings workflow to manage active environments through the EnvironmentManager API only

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e60a7d9b6c8333a2b7a74d8c929f36