### PR TITLE
Normalize container metric dtypes

### DIFF
--- a/app/portainer_client.py
+++ b/app/portainer_client.py
@@ -775,7 +775,14 @@ def normalise_container_details(
                 "labels",
             ]
         )
-    return pd.DataFrame.from_records(records)
+
+    df = pd.DataFrame.from_records(records)
+
+    for column in ("cpu_percent", "memory_usage", "memory_limit", "memory_percent"):
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+
+    return df
 
 
 def normalise_endpoint_host_metrics(


### PR DESCRIPTION
## Summary
- coerce container detail metric columns to numeric types when normalising Portainer data to avoid Arrow conversion errors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6280efc188333829ef7c5ff167ed0