### PR TITLE
Reuse session cookie tokens when logging in

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -137,3 +137,88 @@ def test_store_session_prunes_expired_entries(monkeypatch):
     created = store.retrieve("new-token")
     assert created is not None
     assert created.username == "alice"
+
+
+def test_store_session_reuses_existing_cookie_token(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    token = "existing-token"
+
+    store.create(
+        SessionRecord(
+            token=token,
+            username="alice",
+            authenticated_at=now - timedelta(hours=1),
+            last_active=now - timedelta(minutes=5),
+            session_timeout=timedelta(minutes=30),
+            auth_method="static",
+        )
+    )
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: dict[str, object] = {}
+            self.cookies = {auth.SESSION_COOKIE_NAME: token}
+
+        def experimental_get_cookie(self, name: str) -> str | None:  # pragma: no cover - simple passthrough
+            return self.cookies.get(name)
+
+        def experimental_set_cookie(self, name: str, value: str, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookies[name] = value
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+
+    def fail_token_urlsafe(*_: object) -> str:  # pragma: no cover - defensive assertion
+        raise AssertionError("token_urlsafe should not be called when reusing cookie token")
+
+    monkeypatch.setattr(auth, "token_urlsafe", fail_token_urlsafe)
+
+    auth._store_persistent_session("alice", now, timedelta(minutes=30))
+
+    reused = store.retrieve(token)
+    assert reused is not None
+    assert reused.username == "alice"
+    assert dummy_streamlit.session_state["_session_token"] == token
+    assert dummy_streamlit.cookies[auth.SESSION_COOKIE_NAME] == token
+
+
+def test_store_session_replaces_cookie_when_user_changes(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    existing_token = "existing-token"
+
+    store.create(
+        SessionRecord(
+            token=existing_token,
+            username="alice",
+            authenticated_at=now - timedelta(hours=1),
+            last_active=now - timedelta(minutes=5),
+            session_timeout=timedelta(minutes=30),
+            auth_method="static",
+        )
+    )
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: dict[str, object] = {}
+            self.cookies = {auth.SESSION_COOKIE_NAME: existing_token}
+
+        def experimental_get_cookie(self, name: str) -> str | None:  # pragma: no cover - simple passthrough
+            return self.cookies.get(name)
+
+        def experimental_set_cookie(self, name: str, value: str, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookies[name] = value
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+    monkeypatch.setattr(auth, "token_urlsafe", lambda *_: "new-token")
+
+    auth._store_persistent_session("bob", now, timedelta(minutes=30))
+
+    assert store.retrieve(existing_token) is None
+    replacement = store.retrieve("new-token")
+    assert replacement is not None
+    assert replacement.username == "bob"
+    assert dummy_streamlit.session_state["_session_token"] == "new-token"
+    assert dummy_streamlit.cookies[auth.SESSION_COOKIE_NAME] == "new-token"


### PR DESCRIPTION
## Summary
- reuse the existing browser session token when creating a new authenticated session
- discard stale cookie tokens when the username changes to prevent ghost sessions
- add regression tests covering cookie reuse and replacement scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e62cf2c9a483339e79d1a0be8a0aba