### PR TITLE
Reject unrecognized session cookies

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -578,8 +578,24 @@ def _store_persistent_session(
     """Create and persist a new session token for the authenticated user."""
 
     _prune_expired_sessions(now=now)
-    token = token_urlsafe(32)
-    _get_session_storage().create(
+    storage = _get_session_storage()
+
+    token_from_cookie = _get_session_token_from_cookie()
+    token: str | None = None
+
+    if token_from_cookie:
+        session = storage.retrieve(token_from_cookie)
+        if session is None:
+            storage.delete(token_from_cookie)
+        elif session.username != username:
+            storage.delete(token_from_cookie)
+        else:
+            token = token_from_cookie
+
+    if token is None:
+        token = token_urlsafe(32)
+
+    storage.create(
         SessionRecord(
             token=token,
             username=username,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -137,3 +137,122 @@ def test_store_session_prunes_expired_entries(monkeypatch):
     created = store.retrieve("new-token")
     assert created is not None
     assert created.username == "alice"
+
+
+def test_store_session_reuses_existing_cookie_token(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    token = "existing-token"
+
+    store.create(
+        SessionRecord(
+            token=token,
+            username="alice",
+            authenticated_at=now - timedelta(hours=1),
+            last_active=now - timedelta(minutes=5),
+            session_timeout=timedelta(minutes=30),
+            auth_method="static",
+        )
+    )
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: dict[str, object] = {}
+            self.cookies = {auth.SESSION_COOKIE_NAME: token}
+
+        def experimental_get_cookie(self, name: str) -> str | None:  # pragma: no cover - simple passthrough
+            return self.cookies.get(name)
+
+        def experimental_set_cookie(self, name: str, value: str, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookies[name] = value
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+
+    def fail_token_urlsafe(*_: object) -> str:  # pragma: no cover - defensive assertion
+        raise AssertionError("token_urlsafe should not be called when reusing cookie token")
+
+    monkeypatch.setattr(auth, "token_urlsafe", fail_token_urlsafe)
+
+    auth._store_persistent_session("alice", now, timedelta(minutes=30))
+
+    reused = store.retrieve(token)
+    assert reused is not None
+    assert reused.username == "alice"
+    assert dummy_streamlit.session_state["_session_token"] == token
+    assert dummy_streamlit.cookies[auth.SESSION_COOKIE_NAME] == token
+
+
+def test_store_session_rejects_unknown_cookie_token(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: dict[str, object] = {}
+            self.cookies = {auth.SESSION_COOKIE_NAME: "attacker-token"}
+
+        def experimental_get_cookie(self, name: str) -> str | None:  # pragma: no cover - simple passthrough
+            return self.cookies.get(name)
+
+        def experimental_set_cookie(self, name: str, value: str, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookies[name] = value
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+
+    generated_tokens: list[str] = []
+
+    def fake_token_urlsafe(length: int) -> str:
+        generated_tokens.append("called")
+        return "fresh-token"
+
+    monkeypatch.setattr(auth, "token_urlsafe", fake_token_urlsafe)
+
+    auth._store_persistent_session("alice", now, timedelta(minutes=30))
+
+    assert generated_tokens, "Expected a new token to be generated"
+    assert store.retrieve("fresh-token") is not None
+    assert dummy_streamlit.session_state["_session_token"] == "fresh-token"
+    assert dummy_streamlit.cookies[auth.SESSION_COOKIE_NAME] == "fresh-token"
+
+
+def test_store_session_replaces_cookie_when_user_changes(monkeypatch):
+    store = _setup_session_store(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    existing_token = "existing-token"
+
+    store.create(
+        SessionRecord(
+            token=existing_token,
+            username="alice",
+            authenticated_at=now - timedelta(hours=1),
+            last_active=now - timedelta(minutes=5),
+            session_timeout=timedelta(minutes=30),
+            auth_method="static",
+        )
+    )
+
+    class DummyStreamlit:
+        def __init__(self) -> None:
+            self.session_state: dict[str, object] = {}
+            self.cookies = {auth.SESSION_COOKIE_NAME: existing_token}
+
+        def experimental_get_cookie(self, name: str) -> str | None:  # pragma: no cover - simple passthrough
+            return self.cookies.get(name)
+
+        def experimental_set_cookie(self, name: str, value: str, **kwargs) -> None:  # pragma: no cover - data capture only
+            self.cookies[name] = value
+
+    dummy_streamlit = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_streamlit)
+    monkeypatch.setattr(auth, "token_urlsafe", lambda *_: "new-token")
+
+    auth._store_persistent_session("bob", now, timedelta(minutes=30))
+
+    assert store.retrieve(existing_token) is None
+    replacement = store.retrieve("new-token")
+    assert replacement is not None
+    assert replacement.username == "bob"
+    assert dummy_streamlit.session_state["_session_token"] == "new-token"
+    assert dummy_streamlit.cookies[auth.SESSION_COOKIE_NAME] == "new-token"


### PR DESCRIPTION
## Summary
- ensure persistent sessions only reuse cookie tokens that map to existing sessions for the same user
- generate new session tokens when cookies contain unknown values instead of attacker-supplied values
- cover the token replacement behaviour with a regression test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e62cf2c9a483339e79d1a0be8a0aba