### PR TITLE
Fix session token cookie handling indentation

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -588,7 +588,6 @@ def _store_persistent_session(
         if session is None:
             storage.delete(token_from_cookie)
         elif session.username != username:
-        if session is not None and session.username != username:
             storage.delete(token_from_cookie)
         else:
             token = token_from_cookie


### PR DESCRIPTION
## Summary
- correct the indentation when validating stored session tokens to avoid syntax errors on startup

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e63640d9908333be00d5f31fc7ccd9