### PR TITLE
Add backend field validator to handle None and empty string values

### DIFF
--- a/src/portainer_dashboard/config.py
+++ b/src/portainer_dashboard/config.py
@@ -272,6 +272,13 @@ class SessionSettings(BaseSettings):
     backend: Literal["memory", "sqlite"] = "memory"
     sqlite_path: Path = Field(default_factory=lambda: PROJECT_ROOT / ".data" / "sessions.db")
 
+    @field_validator("backend", mode="before")
+    @classmethod
+    def parse_backend(cls, v: str | None) -> str:
+        if v is None or v == "":
+            return "memory"
+        return v
+
     @field_validator("sqlite_path", mode="before")
     @classmethod
     def expand_sqlite_path(cls, v: str | Path | None) -> Path:


### PR DESCRIPTION
## Summary
Added a field validator to the `SessionSettings.backend` field to gracefully handle `None` and empty string values by defaulting to "memory" backend.

## Changes
- Added `parse_backend` field validator to `SessionSettings` class that:
  - Converts `None` values to "memory" backend
  - Converts empty strings to "memory" backend
  - Passes through all other values unchanged
- Validator runs in "before" mode to normalize input before Pydantic's type validation

## Details
This validator ensures that the session backend configuration is always set to a valid value, preventing potential issues from missing or empty environment variables or configuration values. The "memory" backend is used as the sensible default when no explicit backend is specified.