### PR TITLE
Increase API timeout defaults to 60s for slow external APIs

### DIFF
--- a/src/portainer_dashboard/config.py
+++ b/src/portainer_dashboard/config.py
@@ -170,6 +170,7 @@ class PortainerEnvironmentSettings(BaseSettings):
     api_url: str
     api_key: str
     verify_ssl: bool = True
+    timeout: float = 60.0  # Increased from 30s to handle slow API responses
 
 
 class PortainerSettings(BaseSettings):
@@ -183,6 +184,7 @@ class PortainerSettings(BaseSettings):
     api_url: str | None = None
     api_key: str | None = None
     verify_ssl: bool = True
+    timeout: float = 60.0  # Increased from 30s to handle slow API responses
     environment_name: str = "Default"
     environments: str = ""
 
@@ -198,6 +200,8 @@ class PortainerSettings(BaseSettings):
                 api_key = os.getenv(f"PORTAINER_{key_prefix}_API_KEY", "").strip()
                 verify_ssl_raw = os.getenv(f"PORTAINER_{key_prefix}_VERIFY_SSL", "true")
                 verify_ssl = verify_ssl_raw.strip().lower() not in {"0", "false", "no", "off"}
+                timeout_raw = os.getenv(f"PORTAINER_{key_prefix}_TIMEOUT", "").strip()
+                timeout = float(timeout_raw) if timeout_raw else self.timeout
                 if api_url and api_key:
                     configured.append(
                         PortainerEnvironmentSettings(
@@ -205,6 +209,7 @@ class PortainerSettings(BaseSettings):
                             api_url=api_url,
                             api_key=api_key,
                             verify_ssl=verify_ssl,
+                            timeout=timeout,
                         )
                     )
             return configured
@@ -216,6 +221,7 @@ class PortainerSettings(BaseSettings):
                     api_url=self.api_url,
                     api_key=self.api_key,
                     verify_ssl=self.verify_ssl,
+                    timeout=self.timeout,
                 )
             )
         return configured
@@ -248,7 +254,7 @@ class KibanaSettings(BaseSettings):
     logs_endpoint: str | None = None
     api_key: str | None = None
     verify_ssl: bool = True
-    timeout_seconds: int = 30
+    timeout_seconds: int = 60  # Increased from 30s to handle slow API responses
 
     @property
     def timeout(self) -> int:

--- a/src/portainer_dashboard/services/data_collector.py
+++ b/src/portainer_dashboard/services/data_collector.py
@@ -88,7 +88,7 @@ class DataCollector:
     max_containers_for_logs: int = 10
     log_fetch_timeout: float = 10.0
     max_endpoints_per_env: int = 50
-    container_fetch_timeout: float = 30.0
+    container_fetch_timeout: float = 60.0  # Increased from 30s to handle slow API responses
 
     async def collect_endpoint_data(
         self,

--- a/src/portainer_dashboard/services/kibana_client.py
+++ b/src/portainer_dashboard/services/kibana_client.py
@@ -84,7 +84,7 @@ class AsyncKibanaClient:
     endpoint: str
     api_key: str
     verify_ssl: bool = True
-    timeout: int = 30
+    timeout: int = 60  # Increased from 30s to handle slow API responses
 
     def __post_init__(self) -> None:
         if not self.endpoint:

--- a/src/portainer_dashboard/services/portainer_client.py
+++ b/src/portainer_dashboard/services/portainer_client.py
@@ -115,7 +115,7 @@ class AsyncPortainerClient:
 
     base_url: str
     api_key: str
-    timeout: float = 30.0
+    timeout: float = 60.0  # Increased from 30s to handle slow API responses
     verify_ssl: bool = True
     _client: httpx.AsyncClient = field(init=False, repr=False)
 
@@ -481,6 +481,7 @@ def create_portainer_client(
         base_url=env.api_url,
         api_key=env.api_key,
         verify_ssl=env.verify_ssl,
+        timeout=env.timeout,
     )
 
 

--- a/streamlit_ui/api_client.py
+++ b/streamlit_ui/api_client.py
@@ -14,6 +14,12 @@ LOGGER = logging.getLogger(__name__)
 # Backend URL - can be overridden by environment variable
 BACKEND_URL = os.getenv("FASTAPI_BACKEND_URL", "http://localhost:8000")
 
+# API timeout settings (in seconds)
+# Default increased to 60s to handle slow external API responses (Portainer, LLM)
+API_TIMEOUT = float(os.getenv("STREAMLIT_API_TIMEOUT", "60.0"))
+API_TIMEOUT_LOGIN = float(os.getenv("STREAMLIT_API_TIMEOUT_LOGIN", "30.0"))
+API_TIMEOUT_SESSION = float(os.getenv("STREAMLIT_API_TIMEOUT_SESSION", "10.0"))
+
 
 SESSION_COOKIE_NAME = "dashboard_session_token"
 
@@ -86,7 +92,7 @@ class APIClient:
         return httpx.Client(
             base_url=self.base_url,
             cookies=cookies,
-            timeout=30.0,
+            timeout=API_TIMEOUT,
         )
 
     def login(self, username: str, password: str, remember_me: bool = False) -> bool:
@@ -99,7 +105,7 @@ class APIClient:
                         survives browser restarts.
         """
         try:
-            with httpx.Client(base_url=self.base_url, timeout=30.0) as client:
+            with httpx.Client(base_url=self.base_url, timeout=API_TIMEOUT_LOGIN) as client:
                 form_data = {
                     "username": username,
                     "password": password,
@@ -171,7 +177,7 @@ class APIClient:
             with httpx.Client(
                 base_url=self.base_url,
                 cookies={SESSION_COOKIE_NAME: cookie_value},
-                timeout=10.0,
+                timeout=API_TIMEOUT_SESSION,
             ) as client:
                 response = client.get("/auth/validate")
 


### PR DESCRIPTION
## Summary
This PR increases the default timeout values across the application from 30 seconds to 60 seconds to better handle slow responses from external APIs (Portainer, Kibana, LLM services). It also makes timeout values configurable via environment variables for better flexibility in different deployment environments.

## Key Changes

- **Configuration Settings**: Updated default timeouts in `PortainerEnvironmentSettings`, `PortainerSettings`, and `KibanaSettings` from 30s to 60s
- **Environment Variable Support**: Added configurable timeout via `PORTAINER_*_TIMEOUT` environment variables for individual Portainer environments
- **Streamlit API Client**: Made timeout configurable with three separate settings:
  - `STREAMLIT_API_TIMEOUT` (default 60s) - general API calls
  - `STREAMLIT_API_TIMEOUT_LOGIN` (default 30s) - login requests
  - `STREAMLIT_API_TIMEOUT_SESSION` (default 10s) - session validation
- **Service Clients**: Updated timeout defaults in:
  - `AsyncPortainerClient` (30s → 60s)
  - `AsyncKibanaClient` (30s → 60s)
  - `DataCollector.container_fetch_timeout` (30s → 60s)
- **Client Instantiation**: Updated `create_portainer_client()` to pass timeout from environment settings

## Implementation Details

- All timeout increases are backward compatible - existing deployments will use the new 60s default
- Environment variables allow per-environment customization without code changes
- Different timeout values for different operations (login, session, general) provide granular control
- Comments added to explain the rationale for increased timeouts