### PR TITLE
Use _determine_edge_agent_status for proper endpoint status detection

### DIFF
--- a/src/portainer_dashboard/services/metrics_collector.py
+++ b/src/portainer_dashboard/services/metrics_collector.py
@@ -12,6 +12,7 @@ from portainer_dashboard.services.metrics_store import SQLiteMetricsStore, get_m
 from portainer_dashboard.services.portainer_client import (
     AsyncPortainerClient,
     PortainerAPIError,
+    _determine_edge_agent_status,
     create_portainer_client,
 )
 
@@ -279,8 +280,15 @@ class MetricsCollector:
                     endpoint_name = endpoint.get("Name") or endpoint.get("name") or env.name
 
                     # Only collect from online endpoints
-                    status = endpoint.get("Status") or endpoint.get("status")
+                    # Use _determine_edge_agent_status for proper edge agent detection
+                    raw_status = endpoint.get("Status") or endpoint.get("status")
+                    status = _determine_edge_agent_status(endpoint, raw_status)
                     if status != 1:
+                        LOGGER.debug(
+                            "Skipping offline endpoint %s (status=%s)",
+                            endpoint_name,
+                            status,
+                        )
                         continue
 
                     try:

--- a/src/portainer_dashboard/services/portainer_client.py
+++ b/src/portainer_dashboard/services/portainer_client.py
@@ -906,6 +906,7 @@ def normalise_endpoint_images(
 __all__ = [
     "AsyncPortainerClient",
     "PortainerAPIError",
+    "_determine_edge_agent_status",
     "create_portainer_client",
     "normalise_endpoint_containers",
     "normalise_endpoint_images",


### PR DESCRIPTION
## Summary
This PR improves endpoint status detection by consistently using the `_determine_edge_agent_status` function across data and metrics collection services. This ensures proper handling of edge agent endpoints when determining if an endpoint is online.

## Key Changes
- Imported `_determine_edge_agent_status` function in `data_collector.py` and `metrics_collector.py`
- Updated endpoint status detection in `collect_endpoint_data()` to use `_determine_edge_agent_status()` instead of directly accessing the status field
- Updated endpoint status detection in `collect_metrics_for_endpoint()` to use `_determine_edge_agent_status()` instead of directly accessing the status field
- Added debug logging when skipping offline endpoints in both collectors for better observability
- Exported `_determine_edge_agent_status` in the `__all__` list in `portainer_client.py`

## Implementation Details
The `_determine_edge_agent_status` function provides specialized logic for detecting edge agent status that goes beyond simple field access. By centralizing this logic, we ensure consistent behavior across all endpoint status checks and improve reliability when working with edge agent endpoints.

Debug logging has been added to help troubleshoot endpoint connectivity issues by clearly indicating which endpoints are being skipped and their status values.