### PR TITLE
Fix dashboard API: use correct auth dependency get_current_user

### DIFF
--- a/src/portainer_dashboard/api/v1/dashboard.py
+++ b/src/portainer_dashboard/api/v1/dashboard.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends
 
-from portainer_dashboard.auth.dependencies import require_authenticated
+from portainer_dashboard.auth.dependencies import get_current_user
 from portainer_dashboard.services.cache_service import get_cache_service
 
 LOGGER = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 @router.get(
     "/overview",
     summary="Get dashboard overview data",
-    dependencies=[Depends(require_authenticated)],
+    dependencies=[Depends(get_current_user)],
 )
 async def get_dashboard_overview() -> dict[str, Any]:
     """Get all dashboard data in a single request.
@@ -75,7 +75,7 @@ async def get_dashboard_overview() -> dict[str, Any]:
 @router.get(
     "/summary",
     summary="Get dashboard summary statistics",
-    dependencies=[Depends(require_authenticated)],
+    dependencies=[Depends(get_current_user)],
 )
 async def get_dashboard_summary() -> dict[str, Any]:
     """Get summary statistics for the dashboard.


### PR DESCRIPTION
This pull request updates the authentication dependency for the dashboard overview and summary endpoints. Instead of using the previous `require_authenticated` dependency, both endpoints now use `get_current_user` to handle user authentication.

**Authentication dependency updates:**

* Replaced `require_authenticated` with `get_current_user` in the imports and as a dependency for both the `/overview` and `/summary` dashboard endpoints in `dashboard.py`. [[1]](diffhunk://#diff-5d36f40eadf7171310975b294f151fe7bb627ddf26fdf186cf4e6af923310af5L16-R16) [[2]](diffhunk://#diff-5d36f40eadf7171310975b294f151fe7bb627ddf26fdf186cf4e6af923310af5L27-R27) [[3]](diffhunk://#diff-5d36f40eadf7171310975b294f151fe7bb627ddf26fdf186cf4e6af923310af5L78-R78)