### PR TITLE
Fix CVE-2025-7709: Update libsqlite3-0 in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,16 @@ COPY static ./static
 # Create data directory for sessions/cache and set ownership
 RUN mkdir -p /app/data && chown -R 65532:65532 /app/data
 
-# --- Runtime stage (3.14, DHI nonroot image) ---
-FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
-
 # Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
-USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# --- Runtime stage (3.14, DHI nonroot image) ---
+FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
+
+# Copy updated libsqlite3 from build stage to fix CVE-2025-7709
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN mkdir -p /app/data && chown -R 65532:65532 /app/data
 # --- Runtime stage (3.14, DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
+# Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PATH="/app/venv/bin:$PATH"

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -4,8 +4,10 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Install system dependencies
+# libsqlite3-0 updated to fix CVE-2025-7709 (integer overflow in FTS5 extension)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip to fix CVE-2025-8869, then install dependencies


### PR DESCRIPTION
## Summary
This PR addresses security vulnerability CVE-2025-7709 by updating the `libsqlite3-0` package in both Docker images used by this project.

## Changes
- **Dockerfile**: Added explicit `libsqlite3-0` installation in the runtime stage to fix CVE-2025-7709 (integer overflow in FTS5 extension)
- **Dockerfile.streamlit**: Added `libsqlite3-0` to the system dependencies installation to address the same vulnerability

## Details
CVE-2025-7709 is an integer overflow vulnerability in SQLite's FTS5 (Full-Text Search 5) extension. By explicitly installing the patched version of `libsqlite3-0` in both Dockerfiles, we ensure that the vulnerability is mitigated across all container images built from these configurations.

The updates follow the existing pattern of installing system dependencies with `apt-get` and cleaning up package lists to minimize image size.