### PR TITLE
Make LLM context endpoint limit configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,7 @@ Then create an API key in Portainer UI: Settings → Users → your user → API
 
 **LLM:**
 - `LLM_API_ENDPOINT`, `LLM_MODEL`, `LLM_BEARER_TOKEN`
+- `LLM_CONTEXT_MAX_ENDPOINTS` - Max endpoints included in LLM context (default: 50)
 
 **Kibana:**
 - `KIBANA_LOGS_ENDPOINT`, `KIBANA_API_KEY`

--- a/src/portainer_dashboard/config.py
+++ b/src/portainer_dashboard/config.py
@@ -241,6 +241,12 @@ class LLMSettings(BaseSettings):
     max_tokens: int = 4096
     ca_bundle: str | None = None
     timeout: int = 60
+    context_max_endpoints: int = 50
+
+    @field_validator("context_max_endpoints", mode="before")
+    @classmethod
+    def handle_empty_context_max_endpoints(cls, v: str | int | None) -> int:
+        return _empty_str_to_default_int(v, default=50)
 
 
 class KibanaSettings(BaseSettings):

--- a/src/portainer_dashboard/websocket/llm_chat.py
+++ b/src/portainer_dashboard/websocket/llm_chat.py
@@ -221,7 +221,15 @@ async def _build_context_uncached() -> str:
                 )
 
                 # Get containers and stacks for each endpoint in parallel
-                all_endpoints: list[dict] = list(endpoints[:10])  # Limit to first 10 endpoints for context
+                max_endpoints = settings.llm.context_max_endpoints
+                if len(endpoints) > max_endpoints:
+                    LOGGER.warning(
+                        "Truncating LLM context from %d to %d endpoints. "
+                        "Set LLM_CONTEXT_MAX_ENDPOINTS to increase this limit.",
+                        len(endpoints),
+                        max_endpoints,
+                    )
+                all_endpoints: list[dict] = list(endpoints[:max_endpoints])
                 containers_by_endpoint: dict[int, list[dict]] = {}
                 stacks_by_endpoint: dict[int, list[dict]] = {}
 


### PR DESCRIPTION
## Summary
This PR makes the maximum number of endpoints included in LLM context configurable via the `LLM_CONTEXT_MAX_ENDPOINTS` environment variable, replacing the hardcoded limit of 10 endpoints.

## Changes
- Added `LLM_CONTEXT_MAX_ENDPOINTS` configuration option to `LLMSettings` with a default value of 50
- Implemented field validator to handle empty string values and convert them to the default integer
- Updated the LLM context building logic to use the configurable limit instead of hardcoded value of 10
- Added warning log when endpoint list exceeds the configured limit, informing users how to increase it
- Updated documentation in CLAUDE.md to describe the new configuration option

## Implementation Details
- The default limit was increased from 10 to 50 endpoints to provide better context while remaining performant
- A warning is logged when truncation occurs to help users understand why their endpoints might be missing from LLM context
- The field validator follows the existing pattern used for other optional integer settings in the codebase

https://claude.ai/code/session_01McExq3RtiZCTrxjGP1GeqB