### PR TITLE
Upgrade actions/upload-artifact from v4 to v6

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-test-results
           path: test-results/
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: playwright-report/

--- a/docs/plans/LARGE_INITIATIVES_PLAN.md
+++ b/docs/plans/LARGE_INITIATIVES_PLAN.md
@@ -494,7 +494,7 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: playwright install chromium
       - run: pytest tests/e2e -v --screenshot=on --video=on
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: test-results


### PR DESCRIPTION
## Summary
This pull request upgrades the `actions/upload-artifact` GitHub Action from version 4 to version 6 across the CI/CD configuration and documentation.

## Changes
- Updated `.github/workflows/e2e.yml` to use `actions/upload-artifact@v6` for both test results and Playwright report uploads
- Updated `docs/plans/LARGE_INITIATIVES_PLAN.md` to reflect the same version upgrade in documented examples

## Details
The upgrade affects two artifact upload steps in the e2e workflow:
1. E2E test results upload
2. Playwright report upload

This ensures the workflow uses the latest stable version of the upload-artifact action, which may include performance improvements, bug fixes, and new features compared to v4.

https://claude.ai/code/session_01DPr8zkXHpGf7frR8hL2z99