### PR TITLE
Upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
     needs: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -84,7 +84,7 @@ jobs:
     needs: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/plans/LARGE_INITIATIVES_PLAN.md
+++ b/docs/plans/LARGE_INITIATIVES_PLAN.md
@@ -487,7 +487,7 @@ jobs:
         ports:
           - 9000:9000
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14'


### PR DESCRIPTION
## Summary
This pull request upgrades the `actions/checkout` action from v4 to v6 across all GitHub Actions workflows and documentation.

## Changes
- Updated `actions/checkout` from v4 to v6 in `.github/workflows/ci.yml` (3 occurrences)
- Updated `actions/checkout` from v4 to v6 in `.github/workflows/e2e.yml` (1 occurrence)
- Updated `actions/checkout` from v4 to v6 in `docs/plans/LARGE_INITIATIVES_PLAN.md` (1 occurrence)

## Details
This upgrade ensures all CI/CD pipelines and documentation examples use the latest stable version of the checkout action, which includes bug fixes, performance improvements, and security updates. The v6 release maintains backward compatibility with existing workflows while providing enhanced functionality.

https://claude.ai/code/session_01Mq5czJCMhq4V5tyjxNhttW