### PR TITLE
Upgrade actions/setup-python from v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/docs/plans/LARGE_INITIATIVES_PLAN.md
+++ b/docs/plans/LARGE_INITIATIVES_PLAN.md
@@ -488,7 +488,7 @@ jobs:
           - 9000:9000
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - run: pip install -e ".[dev]"


### PR DESCRIPTION
## Summary
This pull request upgrades the `actions/setup-python` GitHub Action from version 5 to version 6 across all workflow files and documentation.

## Changes
- Updated `.github/workflows/ci.yml` to use `actions/setup-python@v6`
- Updated `.github/workflows/e2e.yml` to use `actions/setup-python@v6`
- Updated example workflow in `docs/plans/LARGE_INITIATIVES_PLAN.md` to use `actions/setup-python@v6`

## Details
This upgrade ensures that all CI/CD pipelines and documented examples use the latest stable version of the setup-python action, which may include bug fixes, performance improvements, and enhanced compatibility with newer Python versions (including Python 3.14 referenced in the workflows).

https://claude.ai/code/session_01AxZmL1rtCGyzK2iHF6xTk3