### PR TITLE
Fix OpenSSL vulnerabilities in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ COPY static ./static
 RUN mkdir -p /app/data && chown -R 65532:65532 /app/data
 
 # Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
+# Update libssl3t64 to 3.5.4-1~deb13u2 to fix 2 Critical + 8 High OpenSSL vulnerabilities
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
+    libssl3t64 \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Runtime stage (3.14, DHI nonroot image) ---
@@ -36,6 +38,10 @@ FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
 # Copy updated libsqlite3 from build stage to fix CVE-2025-7709
 COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
+
+# Copy updated libssl/libcrypto from build stage to fix OpenSSL vulnerabilities
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -27,8 +27,10 @@ RUN pip install --no-cache-dir --upgrade pip>=25.3 && \
 COPY streamlit_ui/ /app/
 
 # Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
+# Update libssl3t64 to 3.5.4-1~deb13u2 to fix 2 Critical + 8 High OpenSSL vulnerabilities
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
+    libssl3t64 \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Runtime stage (DHI nonroot image) ---
@@ -36,6 +38,10 @@ FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
 # Copy updated libsqlite3 from build stage to fix CVE-2025-7709
 COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
+
+# Copy updated libssl/libcrypto from build stage to fix OpenSSL vulnerabilities
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
Updates both Dockerfile and Dockerfile.streamlit to patch critical OpenSSL vulnerabilities by installing and copying updated libssl3t64 libraries into the runtime stage.

## Changes
- **Added libssl3t64 package installation** in the build stage of both Dockerfiles to version 3.5.4-1~deb13u2, which fixes 2 Critical and 8 High severity OpenSSL vulnerabilities
- **Copy updated OpenSSL libraries** from build stage to runtime stage:
  - `/usr/lib/x86_64-linux-gnu/libssl.so.3*`
  - `/usr/lib/x86_64-linux-gnu/libcrypto.so.3*`
- Applied identical changes to both `Dockerfile` and `Dockerfile.streamlit` for consistency

## Implementation Details
- Follows the existing pattern used for the libsqlite3 CVE-2025-7709 fix
- Uses multi-stage Docker build to minimize final image size by only copying necessary libraries to runtime stage
- Maintains the `--no-install-recommends` flag to keep image lean
- Cleans up apt cache after installation to reduce layer size

https://claude.ai/code/session_01Wn4pNkmXRGv7oHP4ofi4yJ