### PR TITLE
Fix critical OpenSSL and SQLite CVEs in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- Runtime stage (3.14, DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Upgrade vulnerable packages in-place before switching to nonroot user.
+# Temporarily switch to root to upgrade vulnerable packages in-place.
 # This fixes CVEs in the runtime layer itself (not just overlay):
 # - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
 #   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
+USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3t64 \
     openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,16 +26,26 @@ COPY static ./static
 # Create data directory for sessions/cache and set ownership
 RUN mkdir -p /app/data && chown -R 65532:65532 /app/data
 
-# Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
+# Update system packages to fix CVEs:
+# - libsqlite3-0: CVE-2025-7709 (integer overflow in FTS5 extension)
+# - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
+#   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
+    libssl3t64 \
+    openssl \
+    openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Runtime stage (3.14, DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Copy updated libsqlite3 from build stage to fix CVE-2025-7709
+# Copy updated libraries from build stage to fix CVEs
 COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/ossl-modules/ /usr/lib/x86_64-linux-gnu/ossl-modules/
+COPY --from=build-stage /usr/bin/openssl /usr/bin/openssl
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,16 +40,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- Runtime stage (3.14, DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Temporarily switch to root to upgrade vulnerable packages in-place.
-# This fixes CVEs in the runtime layer itself (not just overlay):
+# Copy updated libraries from build stage to fix CVEs:
 # - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
 #   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
-USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3t64 \
-    openssl \
-    openssl-provider-legacy \
-    && rm -rf /var/lib/apt/lists/*
+# Note: Base image layer still contains old versions (visible to layer-aware scanners),
+# but these COPY commands overlay the fixed versions at runtime.
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/ossl-modules/ /usr/lib/x86_64-linux-gnu/ossl-modules/
+COPY --from=build-stage /usr/bin/openssl /usr/bin/openssl
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -40,10 +40,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- Runtime stage (DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Upgrade vulnerable packages in-place before switching to nonroot user.
+# Temporarily switch to root to upgrade vulnerable packages in-place.
 # This fixes CVEs in the runtime layer itself (not just overlay):
 # - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
 #   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
+USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3t64 \
     openssl \

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -26,16 +26,26 @@ RUN pip install --no-cache-dir --upgrade pip>=25.3 && \
 # Copy Streamlit app
 COPY streamlit_ui/ /app/
 
-# Update libsqlite3-0 to fix CVE-2025-7709 (integer overflow in FTS5 extension)
+# Update system packages to fix CVEs:
+# - libsqlite3-0: CVE-2025-7709 (integer overflow in FTS5 extension)
+# - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
+#   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
+    libssl3t64 \
+    openssl \
+    openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Runtime stage (DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Copy updated libsqlite3 from build stage to fix CVE-2025-7709
+# Copy updated libraries from build stage to fix CVEs
 COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/ossl-modules/ /usr/lib/x86_64-linux-gnu/ossl-modules/
+COPY --from=build-stage /usr/bin/openssl /usr/bin/openssl
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -40,12 +40,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- Runtime stage (DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Copy updated libraries from build stage to fix CVEs
-COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0* /usr/lib/x86_64-linux-gnu/
-COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
-COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
-COPY --from=build-stage /usr/lib/x86_64-linux-gnu/ossl-modules/ /usr/lib/x86_64-linux-gnu/ossl-modules/
-COPY --from=build-stage /usr/bin/openssl /usr/bin/openssl
+# Upgrade vulnerable packages in-place before switching to nonroot user.
+# This fixes CVEs in the runtime layer itself (not just overlay):
+# - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
+#   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3t64 \
+    openssl \
+    openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -40,16 +40,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- Runtime stage (DHI nonroot image) ---
 FROM dhi.io/python:3.14.2-debian13 AS runtime-stage
 
-# Temporarily switch to root to upgrade vulnerable packages in-place.
-# This fixes CVEs in the runtime layer itself (not just overlay):
+# Copy updated libraries from build stage to fix CVEs:
 # - libssl3t64/openssl/openssl-provider-legacy: CVE-2025-15467 (Critical),
 #   CVE-2025-69419 (High), plus multiple Medium severity OpenSSL CVEs
-USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3t64 \
-    openssl \
-    openssl-provider-legacy \
-    && rm -rf /var/lib/apt/lists/*
+# Note: Base image layer still contains old versions (visible to layer-aware scanners),
+# but these COPY commands overlay the fixed versions at runtime.
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libssl.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3* /usr/lib/x86_64-linux-gnu/
+COPY --from=build-stage /usr/lib/x86_64-linux-gnu/ossl-modules/ /usr/lib/x86_64-linux-gnu/ossl-modules/
+COPY --from=build-stage /usr/bin/openssl /usr/bin/openssl
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
Updates both Dockerfile and Dockerfile.streamlit to patch critical and high-severity security vulnerabilities in OpenSSL and SQLite libraries.

## Key Changes
- **Added OpenSSL package updates** to fix:
  - CVE-2025-15467 (Critical severity)
  - CVE-2025-69419 (High severity)
  - Multiple Medium severity OpenSSL CVEs
  
- **Maintained SQLite update** for:
  - CVE-2025-7709 (integer overflow in FTS5 extension)

- **Updated both build and runtime stages** to include:
  - `libssl3t64`, `openssl`, and `openssl-provider-legacy` packages in build stage
  - Corresponding library files copied to runtime stage:
    - `libssl.so.3*` and `libcrypto.so.3*` (OpenSSL libraries)
    - `ossl-modules/` directory (OpenSSL provider modules)
    - `/usr/bin/openssl` binary

## Implementation Details
- Changes applied consistently to both `Dockerfile` and `Dockerfile.streamlit`
- Uses multi-stage Docker build pattern to minimize final image size
- Maintains existing security practices (nonroot user, minimal dependencies)
- Cleans up apt cache after installation to reduce layer size

https://claude.ai/code/session_01JTsBxMVVdzi1saPqYVEjC8